### PR TITLE
Panicking modules now show a message again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-core 0.1.0",
  "redshirt-hardware-interface 0.1.0",
+ "redshirt-stdout-interface 0.1.0",
  "redshirt-wasi-hosted 0.1.0",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "x86_64 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -303,6 +303,18 @@ impl<TExtEx: Clone> System<TExtEx> {
         //println!("answered event {:?}", message_id);
         self.core.answer_message(message_id, response)
     }
+
+    /// Emits a message for the handler of the given interface.
+    ///
+    /// The message doesn't expect any answer.
+    // TODO: better API
+    pub fn emit_interface_message_no_answer(
+        &mut self,
+        interface: [u8; 32],
+        message: impl Encode,
+    ) -> Result<(), ()> {
+        self.core.emit_interface_message_no_answer(interface, message)
+    }
 }
 
 impl<TExtEx: Clone> SystemBuilder<TExtEx> {

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -313,7 +313,8 @@ impl<TExtEx: Clone> System<TExtEx> {
         interface: [u8; 32],
         message: impl Encode,
     ) -> Result<(), ()> {
-        self.core.emit_interface_message_no_answer(interface, message)
+        self.core
+            .emit_interface_message_no_answer(interface, message)
     }
 }
 

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -15,6 +15,7 @@ libm = "0.2.1"
 linked_list_allocator = "0.6.4"
 redshirt-core = { path = "../../core" }
 redshirt-hardware-interface = { path = "../../interfaces/hardware", default-features = false }
+redshirt-stdout-interface = { path = "../../interfaces/stdout", default-features = false }
 redshirt-wasi-hosted = { path = "../hosted-wasi" }
 parity-scale-codec = { version = "1.0.5", default-features = false }
 

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -100,15 +100,13 @@ impl Kernel {
                         message,
                     } = out
                     {
-                        /*if interface == redshirt_stdout_interface::ffi::INTERFACE {
+                        if interface == redshirt_stdout_interface::ffi::INTERFACE {
                             let msg =
                                 redshirt_stdout_interface::ffi::StdoutMessage::decode_all(&message);
-                            let redshirt_stdout_interface::ffi::StdoutMessage::Message(msg) =
-                                msg.unwrap();
-                            console.write(&msg);
-                        } else {*/
-                        panic!()
-                        //}
+                            system.emit_interface_message_no_answer(interface, msg.unwrap());
+                        } else {
+                            panic!()
+                        }
                     }
                 }
                 redshirt_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {


### PR DESCRIPTION
When a module panics, it uses the WASI interfaces to show a message on screen.
The WASI handling code then translates that into a message on the `stdout` interface.
Before this PR, this would then make the kernel panic. This PR fixes that, meaning that panicking modules now properly show a message in the console.
