### PR TITLE
Fix WASI after Rust 1.40 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ dependencies = [
  "redshirt-time-interface 0.1.0",
  "redshirt-wasi-hosted 0.1.0",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1090,6 +1090,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "wasmi"
 version = "0.6.2"
 source = "git+https://github.com/tomaka/wasmi?branch=no-std#31ac62f6f5b18afee668cde494e81dfc6e3a3663"
@@ -1304,6 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 "checksum wasmi 0.6.2 (git+https://github.com/tomaka/wasmi?branch=no-std)" = "<none>"
 "checksum wasmi-validation 0.3.0 (git+https://github.com/tomaka/wasmi?branch=no-std)" = "<none>"
 "checksum wast 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8d1de68310854a9840d39487701a8c1acccb5c9f9f2650d5fce3cdfe6650c372"

--- a/kernel/cli/Cargo.toml
+++ b/kernel/cli/Cargo.toml
@@ -18,7 +18,7 @@ redshirt-time-hosted = { path = "../hosted-time" }
 redshirt-time-interface = { path = "../../interfaces/time" }
 redshirt-wasi-hosted = { path = "../hosted-wasi" }
 parity-scale-codec = "1.0.5"
-wasi = "0.7.0"
+wasi = "0.9.0+wasi-snapshot-preview1"
 
 [build-dependencies]
 walkdir = "2.2.9"

--- a/kernel/hosted-wasi/src/lib.rs
+++ b/kernel/hosted-wasi/src/lib.rs
@@ -325,7 +325,7 @@ impl WasiStateMachine {
                 // nothing is a viable option. This should be implemented properly at some point,
                 // though.
                 HandleOut::Ok
-            },
+            }
             WasiExtrinsicInner::RandomGet => {
                 assert_eq!(params.len(), 2);
                 let buf = params[0].try_into::<i32>().unwrap() as u32;


### PR DESCRIPTION
New versions of Rust are apparently using a new version of WASI.
Unfortunately the environment variables system broke, and I couldn't manage to repair it. I therefore removed the `RUST_BACKTRACE=1` environment variable.