### PR TITLE
Put type definitions in syscalls_interface and use them from core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "redshirt-core 0.1.0",
  "redshirt-hardware-interface 0.1.0",
  "redshirt-stdout-interface 0.1.0",
+ "redshirt-syscalls-interface 0.1.0",
  "redshirt-wasi-hosted 0.1.0",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1012,6 +1013,7 @@ dependencies = [
  "redshirt-core 0.1.0",
  "redshirt-random-interface 0.1.0",
  "redshirt-stdout-interface 0.1.0",
+ "redshirt-syscalls-interface 0.1.0",
  "redshirt-time-interface 0.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,6 +831,7 @@ dependencies = [
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-core 0.1.0",
  "redshirt-stdout-interface 0.1.0",
+ "redshirt-syscalls-interface 0.1.0",
  "redshirt-tcp-hosted 0.1.0",
  "redshirt-tcp-interface 0.1.0",
  "redshirt-time-hosted 0.1.0",

--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -23,26 +23,3 @@ mod vm;
 // TODO: move definition?
 pub use self::ipc::{Core, CoreBuilder, CoreProcess, CoreRunOutcome};
 pub use self::processes::ThreadId;
-
-/// Identifier of a running process within a core.
-// TODO: move to a Pid module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub struct Pid(u64);
-
-impl From<u64> for Pid {
-    fn from(id: u64) -> Pid {
-        Pid(id)
-    }
-}
-
-impl From<Pid> for u64 {
-    fn from(pid: Pid) -> u64 {
-        pid.0
-    }
-}
-
-impl fmt::Debug for Pid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "#{}", self.0)
-    }
-}

--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -22,4 +22,3 @@ mod vm;
 
 // TODO: move definition?
 pub use self::ipc::{Core, CoreBuilder, CoreProcess, CoreRunOutcome};
-pub use self::processes::ThreadId;

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -23,8 +23,8 @@ use alloc::{borrow::Cow, collections::VecDeque, vec, vec::Vec};
 use byteorder::{ByteOrder as _, LittleEndian};
 use core::{convert::TryFrom, iter, marker::PhantomData, mem};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
-use redshirt_syscalls_interface::{Pid, MessageId, ThreadId};
 use parity_scale_codec::Encode;
+use redshirt_syscalls_interface::{MessageId, Pid, ThreadId};
 use smallvec::SmallVec;
 
 /// Handles scheduling processes and inter-process communications.
@@ -1022,7 +1022,7 @@ fn extrinsic_next_message(
         let mem = thread.read_memory(addr, len * 8)?;
         let mut out = vec![0u64; len as usize];
         byteorder::LittleEndian::read_u64_into(&mem, &mut out);
-        out.into_iter().map(MessageId::from).collect::<Vec<_>>()    // TODO: meh
+        out.into_iter().map(MessageId::from).collect::<Vec<_>>() // TODO: meh
     };
 
     let out_pointer = params[2].try_into::<i32>().ok_or(())? as u32;

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -15,7 +15,7 @@
 
 use crate::id_pool::IdPool;
 use crate::module::Module;
-use crate::scheduler::{processes, vm, ThreadId};
+use crate::scheduler::{processes, vm};
 use crate::sig;
 use crate::signature::Signature;
 
@@ -23,7 +23,7 @@ use alloc::{borrow::Cow, collections::VecDeque, vec, vec::Vec};
 use byteorder::{ByteOrder as _, LittleEndian};
 use core::{convert::TryFrom, iter, marker::PhantomData, mem};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
-use redshirt_syscalls_interface::{Pid, MessageId};
+use redshirt_syscalls_interface::{Pid, MessageId, ThreadId};
 use parity_scale_codec::Encode;
 use smallvec::SmallVec;
 

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -15,7 +15,7 @@
 
 use crate::id_pool::IdPool;
 use crate::module::Module;
-use crate::scheduler::{processes, vm, Pid, ThreadId};
+use crate::scheduler::{processes, vm, ThreadId};
 use crate::sig;
 use crate::signature::Signature;
 
@@ -23,6 +23,7 @@ use alloc::{borrow::Cow, collections::VecDeque, vec, vec::Vec};
 use byteorder::{ByteOrder as _, LittleEndian};
 use core::{convert::TryFrom, iter, marker::PhantomData, mem};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
+use redshirt_syscalls_interface::{Pid, MessageId};
 use parity_scale_codec::Encode;
 use smallvec::SmallVec;
 

--- a/core/src/scheduler/processes.rs
+++ b/core/src/scheduler/processes.rs
@@ -15,7 +15,7 @@
 
 use crate::id_pool::IdPool;
 use crate::module::Module;
-use crate::scheduler::{vm, Pid};
+use crate::scheduler::vm;
 use crate::signature::Signature;
 use alloc::{borrow::Cow, vec::Vec};
 use core::fmt;
@@ -24,6 +24,7 @@ use hashbrown::{
     HashMap,
 };
 use rand::seq::SliceRandom as _;
+use redshirt_syscalls_interface::Pid;
 
 /// Collection of multiple [`ProcessStateMachine`](vm::ProcessStateMachine)s grouped together in a
 /// smart way.

--- a/core/src/scheduler/processes.rs
+++ b/core/src/scheduler/processes.rs
@@ -24,7 +24,7 @@ use hashbrown::{
     HashMap,
 };
 use rand::seq::SliceRandom as _;
-use redshirt_syscalls_interface::Pid;
+use redshirt_syscalls_interface::{Pid, ThreadId};
 
 /// Collection of multiple [`ProcessStateMachine`](vm::ProcessStateMachine)s grouped together in a
 /// smart way.
@@ -63,12 +63,6 @@ pub struct ProcessesCollectionBuilder<TExtr> {
     /// See the corresponding field in `ProcessesCollection`.
     extrinsics_id_assign: HashMap<(Cow<'static, str>, Cow<'static, str>), (usize, Signature)>,
 }
-
-/// Identifier of a thread within the [`ProcessesCollection`].
-///
-/// No two threads share the same ID, even between multiple processes.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ThreadId(u64);
 
 /// Single running process in the list.
 struct Process<TPud, TTud> {
@@ -445,12 +439,6 @@ impl<TExtr> ProcessesCollectionBuilder<TExtr> {
             extrinsics: self.extrinsics,
             extrinsics_id_assign: self.extrinsics_id_assign,
         }
-    }
-}
-
-impl From<u64> for ThreadId {
-    fn from(id: u64) -> ThreadId {
-        ThreadId(id)
     }
 }
 

--- a/core/src/scheduler/vm.rs
+++ b/core/src/scheduler/vm.rs
@@ -21,7 +21,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{cell::RefCell, convert::TryInto, fmt};
-use redshirt_syscalls_interface::{Pid, MessageId};
+use redshirt_syscalls_interface::{MessageId, Pid};
 use smallvec::SmallVec;
 
 /// WASMI state machine dedicated to a process.

--- a/core/src/scheduler/vm.rs
+++ b/core/src/scheduler/vm.rs
@@ -21,6 +21,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{cell::RefCell, convert::TryInto, fmt};
+use redshirt_syscalls_interface::{Pid, MessageId};
 use smallvec::SmallVec;
 
 /// WASMI state machine dedicated to a process.

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -19,7 +19,7 @@ use crate::signature::Signature;
 use alloc::{borrow::Cow, vec, vec::Vec};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use parity_scale_codec::{DecodeAll, Encode};
-use redshirt_syscalls_interface::{Pid, MessageId, ThreadId};
+use redshirt_syscalls_interface::{MessageId, Pid, ThreadId};
 use smallvec::SmallVec;
 
 /// Main struct that handles a system, including the scheduler, program loader,

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -40,7 +40,7 @@ pub struct System<TExtEx> {
     /// oldest message.
     ///
     /// See the "threads" interface for documentation about what a futex is.
-    futex_waits: HashMap<(Pid, u32), SmallVec<[u64; 4]>>,
+    futex_waits: HashMap<(Pid, u32), SmallVec<[MessageId; 4]>>,
 
     /// List of programs to load as soon as a loader interface handler is available.
     ///
@@ -55,7 +55,7 @@ pub struct System<TExtEx> {
     /// Set of messages that we emitted of requests to load a program from the loader interface.
     /// All these messages expect a `redshirt_loader_interface::ffi::LoadResponse` as answer.
     // TODO: call shink_to_fit from time to time
-    loading_programs: HashSet<u64>,
+    loading_programs: HashSet<MessageId>,
 }
 
 /// Prototype for a [`System`].
@@ -106,7 +106,7 @@ pub enum SystemRunOutcome<TExtEx> {
         pid: Pid,
         /// If `Some`, identifier of the message to use to send the answer. If `None`, the message
         /// doesn't expect any answer.
-        message_id: Option<u64>,
+        message_id: Option<MessageId>,
         /// Interface the message was emitted on. Matches what was passed to
         /// [`SystemBuilder::with_interface_handler`].
         interface: [u8; 32],
@@ -311,7 +311,7 @@ impl<TExtEx: Clone> System<TExtEx> {
     /// After [`SystemRunOutcome::InterfaceMessage`] has been returned, call this method in order
     /// to send back an answer to the message.
     // TODO: better API
-    pub fn answer_message(&mut self, message_id: u64, response: Result<&[u8], ()>) {
+    pub fn answer_message(&mut self, message_id: MessageId, response: Result<&[u8], ()>) {
         //println!("answered event {:?}", message_id);
         self.core.answer_message(message_id, response)
     }

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -14,11 +14,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::module::Module;
-use crate::scheduler::{Core, CoreBuilder, CoreRunOutcome, Pid, ThreadId};
+use crate::scheduler::{Core, CoreBuilder, CoreRunOutcome, ThreadId};
 use crate::signature::Signature;
 use alloc::{borrow::Cow, vec, vec::Vec};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use parity_scale_codec::{DecodeAll, Encode};
+use redshirt_syscalls_interface::{Pid, MessageId};
 use smallvec::SmallVec;
 
 /// Main struct that handles a system, including the scheduler, program loader,

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -14,12 +14,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::module::Module;
-use crate::scheduler::{Core, CoreBuilder, CoreRunOutcome, ThreadId};
+use crate::scheduler::{Core, CoreBuilder, CoreRunOutcome};
 use crate::signature::Signature;
 use alloc::{borrow::Cow, vec, vec::Vec};
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 use parity_scale_codec::{DecodeAll, Encode};
-use redshirt_syscalls_interface::{Pid, MessageId};
+use redshirt_syscalls_interface::{Pid, MessageId, ThreadId};
 use smallvec::SmallVec;
 
 /// Main struct that handles a system, including the scheduler, program loader,

--- a/interfaces/syscalls/src/block_on.rs
+++ b/interfaces/syscalls/src/block_on.rs
@@ -34,7 +34,7 @@
 //!   Repeat until the `Future` has ended.
 //!
 
-use crate::{Decode, InterfaceMessage, InterfaceOrDestroyed, Message, ResponseMessage};
+use crate::{Decode, InterfaceMessage, InterfaceOrDestroyed, Message, MessageId, ResponseMessage};
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 use core::{
     sync::atomic::{AtomicBool, Ordering},
@@ -50,17 +50,17 @@ use spin::Mutex;
 ///
 /// For non-interface messages, there can only ever be one registered `Waker`. Registering a
 /// `Waker` a second time overrides the one previously registered.
-pub(crate) fn register_message_waker(message_id: u64, waker: Waker) {
+pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) {
     let mut state = (&*STATE).lock();
 
-    if message_id != 1 {
-        if let Some(pos) = state.message_ids.iter().position(|msg| *msg == message_id) {
+    if message_id != From::from(1) {
+        if let Some(pos) = state.message_ids.iter().position(|msg| *msg == From::from(message_id)) {
             state.wakers[pos] = waker;
             return;
         }
     }
 
-    state.message_ids.push(message_id);
+    state.message_ids.push(From::from(message_id));
     state.wakers.push(waker);
 }
 
@@ -71,7 +71,7 @@ pub(crate) fn peek_interface_message() -> Option<InterfaceOrDestroyed> {
 }
 
 /// If a response to this message ID has previously been obtained, extracts it for processing.
-pub(crate) fn peek_response(msg_id: u64) -> Option<ResponseMessage> {
+pub(crate) fn peek_response(msg_id: MessageId) -> Option<ResponseMessage> {
     let mut state = (&*STATE).lock();
     state.pending_messages.remove(&msg_id)
 }
@@ -192,7 +192,7 @@ struct BlockOnState {
     /// > **Note**: We have to maintain this queue as a global variable rather than a per-future
     /// >           channel, otherwise dropping a `Future` would silently drop messages that have
     /// >           already been received.
-    pending_messages: HashMap<u64, ResponseMessage>,
+    pending_messages: HashMap<MessageId, ResponseMessage>,
 
     /// Queue of interface messages waiting to be delivered.
     ///

--- a/interfaces/syscalls/src/block_on.rs
+++ b/interfaces/syscalls/src/block_on.rs
@@ -54,7 +54,11 @@ pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) {
     let mut state = (&*STATE).lock();
 
     if message_id != From::from(1) {
-        if let Some(pos) = state.message_ids.iter().position(|msg| *msg == From::from(message_id)) {
+        if let Some(pos) = state
+            .message_ids
+            .iter()
+            .position(|msg| *msg == From::from(message_id))
+        {
             state.wakers[pos] = waker;
             return;
         }

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -140,9 +140,9 @@ pub unsafe fn emit_message_with_response<'a, T: Decode>(
 }
 
 /// Cancel the given message. No answer will be received.
-pub fn cancel_message(message_id: u64) -> Result<(), CancelMessageErr> {
+pub fn cancel_message(message_id: MessageId) -> Result<(), CancelMessageErr> {
     unsafe {
-        if crate::ffi::cancel_message(&message_id) == 0 {
+        if crate::ffi::cancel_message(&u64::from(message_id)) == 0 {
             Ok(())
         } else {
             Err(CancelMessageErr::InvalidMessageId)
@@ -215,7 +215,7 @@ impl<T: Decode> Future for EmitMessageWithResponse<T> {
 impl<T> PinnedDrop for EmitMessageWithResponse<T> {
     fn drop(self: Pin<&mut Self>) {
         if self.inner.is_some() {
-            let _ = cancel_message(From::from(self.msg_id));
+            let _ = cancel_message(self.msg_id);
         }
     }
 }

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Decode, Encode};
+use crate::{Decode, Encode, MessageId};
 use core::{
     fmt,
     mem::MaybeUninit,
@@ -42,9 +42,10 @@ pub unsafe fn emit_message<'a>(
     interface_hash: &[u8; 32],
     msg: impl Encode<'a>,
     needs_answer: bool,
-) -> Result<Option<u64>, EmitErr> {
+) -> Result<Option<MessageId>, EmitErr> {
     let encoded = msg.encode();
     emit_message_raw(interface_hash, &encoded, needs_answer)
+        .map(|r| r.map(MessageId::from))
 }
 
 /// Emits a message destined to the handler of the given interface.
@@ -87,7 +88,7 @@ pub unsafe fn emit_message_raw(
     interface_hash: &[u8; 32],
     buf: &[u8],
     needs_answer: bool,
-) -> Result<Option<u64>, EmitErr> {
+) -> Result<Option<MessageId>, EmitErr> {
     let mut message_id_out = MaybeUninit::uninit();
 
     let ret = crate::ffi::emit_message(
@@ -104,7 +105,7 @@ pub unsafe fn emit_message_raw(
     }
 
     if needs_answer {
-        Ok(Some(message_id_out.assume_init()))
+        Ok(Some(MessageId::from(message_id_out.assume_init())))
     } else {
         Ok(None)
     }
@@ -187,7 +188,7 @@ pub struct EmitMessageWithResponse<T> {
     #[pin]
     inner: Option<crate::MessageResponseFuture<T>>,
     // TODO: redundant with `inner`
-    msg_id: u64,
+    msg_id: MessageId,
 }
 
 impl<T: Decode> Future for EmitMessageWithResponse<T> {
@@ -215,7 +216,7 @@ impl<T: Decode> Future for EmitMessageWithResponse<T> {
 impl<T> PinnedDrop for EmitMessageWithResponse<T> {
     fn drop(self: Pin<&mut Self>) {
         if self.inner.is_some() {
-            let _ = cancel_message(self.msg_id);
+            let _ = cancel_message(From::from(self.msg_id));
         }
     }
 }

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -44,8 +44,7 @@ pub unsafe fn emit_message<'a>(
     needs_answer: bool,
 ) -> Result<Option<MessageId>, EmitErr> {
     let encoded = msg.encode();
-    emit_message_raw(interface_hash, &encoded, needs_answer)
-        .map(|r| r.map(MessageId::from))
+    emit_message_raw(interface_hash, &encoded, needs_answer).map(|r| r.map(MessageId::from))
 }
 
 /// Emits a message destined to the handler of the given interface.

--- a/interfaces/syscalls/src/ffi.rs
+++ b/interfaces/syscalls/src/ffi.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+use crate::{MessageId, Pid};
+
 use alloc::vec::Vec;
 use parity_scale_codec::{Decode, Encode};
 
@@ -130,14 +132,14 @@ pub struct InterfaceMessage {
     /// Interface the message concerns.
     pub interface: [u8; 32],
     /// Id of the message. Can be used for answering. `None` if no answer is expected.
-    pub message_id: Option<u64>,
+    pub message_id: Option<MessageId>,
     /// Id of the process that emitted the message. `None` if message was emitted by kernel.
     ///
     /// This should be used for security purposes, so that a process can't modify another process'
     /// resources.
     // TODO: consider generating a dummy PID for the kernel so that interface handlers can't treat
     // the kernel differently.
-    pub emitter_pid: Option<u64>,
+    pub emitter_pid: Option<Pid>,
     /// Index within the list to poll where this message was.
     pub index_in_list: u32,
     pub actual_data: Vec<u8>,
@@ -146,7 +148,7 @@ pub struct InterfaceMessage {
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct ProcessDestroyedMessage {
     /// Identifier of the process that got destroyed.
-    pub pid: u64,
+    pub pid: Pid,
     /// Index within the list to poll where this message was.
     pub index_in_list: u32,
 }
@@ -160,7 +162,7 @@ pub enum InterfaceOrDestroyed {
 #[derive(Debug, Encode, Decode)]
 pub struct ResponseMessage {
     /// Identifier of the message whose answer we are receiving.
-    pub message_id: u64,
+    pub message_id: MessageId,
 
     /// Index within the list to poll where this message was.
     pub index_in_list: u32,

--- a/interfaces/syscalls/src/interface_message.rs
+++ b/interfaces/syscalls/src/interface_message.rs
@@ -85,7 +85,7 @@ impl Future for InterfaceMessageFuture {
             self.finished = true;
             Poll::Ready(message)
         } else {
-            crate::block_on::register_message_waker(1, cx.waker().clone());
+            crate::block_on::register_message_waker(From::from(1), cx.waker().clone());
             Poll::Pending
         }
     }

--- a/interfaces/syscalls/src/interface_message.rs
+++ b/interfaces/syscalls/src/interface_message.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ffi::InterfaceOrDestroyed, Encode};
+use crate::{ffi::InterfaceOrDestroyed, Encode, MessageId};
 
 use core::{
     fmt,
@@ -31,10 +31,10 @@ pub fn next_interface_message() -> InterfaceMessageFuture {
 
 /// Answers the given message.
 // TODO: move to interface interface?
-pub fn emit_answer<'a>(message_id: u64, msg: impl Encode<'a>) -> Result<(), EmitAnswerErr> {
+pub fn emit_answer<'a>(message_id: MessageId, msg: impl Encode<'a>) -> Result<(), EmitAnswerErr> {
     unsafe {
         let buf = msg.encode();
-        let ret = crate::ffi::emit_answer(&message_id, buf.as_ptr(), buf.len() as u32);
+        let ret = crate::ffi::emit_answer(&u64::from(message_id), buf.as_ptr(), buf.len() as u32);
         if ret == 0 {
             Ok(())
         } else {
@@ -45,9 +45,9 @@ pub fn emit_answer<'a>(message_id: u64, msg: impl Encode<'a>) -> Result<(), Emit
 
 /// Answers the given message by notifying of an error in the message.
 // TODO: move to interface interface?
-pub fn emit_message_error(message_id: u64) -> Result<(), EmitAnswerErr> {
+pub fn emit_message_error(message_id: MessageId) -> Result<(), EmitAnswerErr> {
     unsafe {
-        if crate::ffi::emit_message_error(&message_id) == 0 {
+        if crate::ffi::emit_message_error(&u64::from(message_id)) == 0 {
             Ok(())
         } else {
             Err(EmitAnswerErr::InvalidMessageId)

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -106,7 +106,7 @@ pub mod ffi;
 
 /// Identifier of a running process within a core.
 // TODO: move to a Pid module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
 pub struct Pid(u64);
 
 impl From<u64> for Pid {
@@ -129,7 +129,7 @@ impl fmt::Debug for Pid {
 
 /// Identifier of a running thread within a core.
 // TODO: move to a separate module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
 pub struct ThreadId(u64);
 
 impl From<u64> for ThreadId {
@@ -152,7 +152,7 @@ impl fmt::Debug for ThreadId {
 
 /// Identifier of a message to answer.
 // TODO: move to a MessageId module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
 pub struct MessageId(u64);
 
 impl From<u64> for MessageId {

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -94,6 +94,8 @@ pub use interface_message::{emit_answer, next_interface_message, InterfaceMessag
 pub use response::{message_response, message_response_sync_raw, MessageResponseFuture};
 pub use traits::{Decode, Encode, EncodedMessage};
 
+use core::fmt;
+
 mod block_on;
 mod emit;
 mod interface_message;
@@ -101,3 +103,49 @@ mod response;
 mod traits;
 
 pub mod ffi;
+
+/// Identifier of a running process within a core.
+// TODO: move to a Pid module?
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct Pid(u64);
+
+impl From<u64> for Pid {
+    fn from(id: u64) -> Pid {
+        Pid(id)
+    }
+}
+
+impl From<Pid> for u64 {
+    fn from(pid: Pid) -> u64 {
+        pid.0
+    }
+}
+
+impl fmt::Debug for Pid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
+
+/// Identifier of a message to answer.
+// TODO: move to a MessageId module?
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct MessageId(u64);
+
+impl From<u64> for MessageId {
+    fn from(id: u64) -> MessageId {
+        MessageId(id)
+    }
+}
+
+impl From<MessageId> for u64 {
+    fn from(pid: MessageId) -> u64 {
+        pid.0
+    }
+}
+
+impl fmt::Debug for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -106,7 +106,9 @@ pub mod ffi;
 
 /// Identifier of a running process within a core.
 // TODO: move to a Pid module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode,
+)]
 pub struct Pid(u64);
 
 impl From<u64> for Pid {
@@ -129,7 +131,9 @@ impl fmt::Debug for Pid {
 
 /// Identifier of a running thread within a core.
 // TODO: move to a separate module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode,
+)]
 pub struct ThreadId(u64);
 
 impl From<u64> for ThreadId {
@@ -152,7 +156,9 @@ impl fmt::Debug for ThreadId {
 
 /// Identifier of a message to answer.
 // TODO: move to a MessageId module?
-#[derive(Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, parity_scale_codec::Encode, parity_scale_codec::Decode,
+)]
 pub struct MessageId(u64);
 
 impl From<u64> for MessageId {

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -127,6 +127,29 @@ impl fmt::Debug for Pid {
     }
 }
 
+/// Identifier of a running thread within a core.
+// TODO: move to a separate module?
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ThreadId(u64);
+
+impl From<u64> for ThreadId {
+    fn from(id: u64) -> ThreadId {
+        ThreadId(id)
+    }
+}
+
+impl From<ThreadId> for u64 {
+    fn from(tid: ThreadId) -> u64 {
+        tid.0
+    }
+}
+
+impl fmt::Debug for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "#{}", self.0)
+    }
+}
+
 /// Identifier of a message to answer.
 // TODO: move to a MessageId module?
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
@@ -139,8 +162,8 @@ impl From<u64> for MessageId {
 }
 
 impl From<MessageId> for u64 {
-    fn from(pid: MessageId) -> u64 {
-        pid.0
+    fn from(mid: MessageId) -> u64 {
+        mid.0
     }
 }
 

--- a/interfaces/syscalls/src/response.rs
+++ b/interfaces/syscalls/src/response.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ffi::Message, Decode};
+use crate::{ffi::Message, MessageId, Pid, Decode};
 
 use alloc::vec::Vec;
 use core::{
@@ -26,8 +26,8 @@ use futures::prelude::*;
 /// Waits until a response to the given message comes back.
 ///
 /// Returns the undecoded response.
-pub fn message_response_sync_raw(msg_id: u64) -> Vec<u8> {
-    match crate::block_on::next_message(&mut [msg_id], true).unwrap() {
+pub fn message_response_sync_raw(msg_id: MessageId) -> Vec<u8> {
+    match crate::block_on::next_message(&mut [msg_id.into()], true).unwrap() {
         Message::Response(m) => m.actual_data.unwrap(),
         _ => panic!(),
     }
@@ -36,7 +36,7 @@ pub fn message_response_sync_raw(msg_id: u64) -> Vec<u8> {
 /// Returns a future that is ready when a response to the given message comes back.
 ///
 /// The return value is the type the message decodes to.
-pub fn message_response<T: Decode>(msg_id: u64) -> MessageResponseFuture<T> {
+pub fn message_response<T: Decode>(msg_id: MessageId) -> MessageResponseFuture<T> {
     MessageResponseFuture {
         finished: false,
         msg_id,
@@ -49,7 +49,7 @@ pub fn message_response<T: Decode>(msg_id: u64) -> MessageResponseFuture<T> {
 /// Future that drives `message_response` to completion.
 #[must_use]
 pub struct MessageResponseFuture<T> {
-    msg_id: u64,
+    msg_id: MessageId,
     finished: bool,
     marker: PhantomData<T>,
 }

--- a/interfaces/syscalls/src/response.rs
+++ b/interfaces/syscalls/src/response.rs
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ffi::Message, MessageId, Pid, Decode};
+use crate::{ffi::Message, Decode, MessageId, Pid};
 
 use alloc::vec::Vec;
 use core::{

--- a/interfaces/tcp/src/lib.rs
+++ b/interfaces/tcp/src/lib.rs
@@ -21,6 +21,7 @@
 
 use futures::{prelude::*, ready};
 use parity_scale_codec::{DecodeAll, Encode as _};
+use redshirt_syscalls_interface::MessageId;
 use std::{
     cmp, io, mem, net::Ipv6Addr, net::SocketAddr, pin::Pin, sync::Arc, task::Context, task::Poll,
     task::Waker,

--- a/kernel/cli/Cargo.toml
+++ b/kernel/cli/Cargo.toml
@@ -12,6 +12,7 @@ async-std = "1.3"
 futures = "0.3.1"
 redshirt-core = { path = "../../core" }
 redshirt-stdout-interface = { path = "../../interfaces/stdout" }
+redshirt-syscalls-interface = { path = "../../interfaces/syscalls" }
 redshirt-tcp-hosted = { path = "../hosted-tcp" }
 redshirt-tcp-interface = { path = "../../interfaces/tcp" }
 redshirt-time-hosted = { path = "../hosted-time" }

--- a/kernel/cli/src/main.rs
+++ b/kernel/cli/src/main.rs
@@ -202,6 +202,6 @@ async fn async_main() {
 }
 
 enum MessageId {
-    Core(u64),
+    Core(redshirt_syscalls_interface::MessageId),
     Wasi(redshirt_wasi_hosted::WasiMessageId),
 }

--- a/kernel/hosted-tcp/src/lib.rs
+++ b/kernel/hosted-tcp/src/lib.rs
@@ -128,7 +128,7 @@ where
     /// Call [`TcpState::next_event`] in order to receive a response (if relevant).
     pub async fn handle_message(
         &self,
-        //emitter_pid: u64,     // TODO: also notify the TcpState when a process exits, for clean up
+        //emitter_pid: MessageId,     // TODO: also notify the TcpState when a process exits, for clean up
         message_id: Option<TMsgId>,
         message: redshirt_tcp_interface::ffi::TcpMessage,
     ) {

--- a/kernel/hosted-wasi/Cargo.toml
+++ b/kernel/hosted-wasi/Cargo.toml
@@ -12,5 +12,6 @@ hashbrown = { version = "0.6.0", default-features = false }
 redshirt-core = { path = "../../core", default-features = false }
 redshirt-random-interface = { path = "../../interfaces/random", default-features = false }
 redshirt-stdout-interface = { path = "../../interfaces/stdout", default-features = false }
+redshirt-syscalls-interface = { path = "../../interfaces/syscalls", default-features = false }
 redshirt-time-interface = { path = "../../interfaces/time", default-features = false }
 parity-scale-codec = { version = "1.1.0", default-features = false }

--- a/kernel/hosted-wasi/src/lib.rs
+++ b/kernel/hosted-wasi/src/lib.rs
@@ -37,8 +37,9 @@ use byteorder::{ByteOrder as _, LittleEndian};
 use core::convert::TryFrom as _;
 use hashbrown::HashMap;
 use parity_scale_codec::{DecodeAll, Encode as _};
-use redshirt_core::scheduler::{Pid, ThreadId};
+use redshirt_core::scheduler::ThreadId;
 use redshirt_core::system::{System, SystemBuilder};
+use redshirt_syscalls_interface::Pid;
 
 // TODO: lots of unwraps as `as` conversions in this module
 
@@ -421,7 +422,7 @@ impl WasiStateMachine {
 
 fn fd_write(
     system: &mut redshirt_core::system::System<impl Clone>,
-    pid: redshirt_core::scheduler::Pid,
+    pid: Pid,
     thread_id: redshirt_core::scheduler::ThreadId,
     params: Vec<redshirt_core::RuntimeValue>,
 ) -> HandleOut {

--- a/kernel/hosted-wasi/src/lib.rs
+++ b/kernel/hosted-wasi/src/lib.rs
@@ -37,9 +37,8 @@ use byteorder::{ByteOrder as _, LittleEndian};
 use core::convert::TryFrom as _;
 use hashbrown::HashMap;
 use parity_scale_codec::{DecodeAll, Encode as _};
-use redshirt_core::scheduler::ThreadId;
 use redshirt_core::system::{System, SystemBuilder};
-use redshirt_syscalls_interface::Pid;
+use redshirt_syscalls_interface::{Pid, ThreadId};
 
 // TODO: lots of unwraps as `as` conversions in this module
 
@@ -423,7 +422,7 @@ impl WasiStateMachine {
 fn fd_write(
     system: &mut redshirt_core::system::System<impl Clone>,
     pid: Pid,
-    thread_id: redshirt_core::scheduler::ThreadId,
+    thread_id: ThreadId,
     params: Vec<redshirt_core::RuntimeValue>,
 ) -> HandleOut {
     assert_eq!(params.len(), 4); // TODO: what to do when it's not the case?

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -18,6 +18,7 @@ parity-scale-codec = { version = "1.0.5", default-features = false }
 redshirt-core = { path = "../../core" }
 redshirt-hardware-interface = { path = "../../interfaces/hardware", default-features = false }
 redshirt-stdout-interface = { path = "../../interfaces/stdout", default-features = false }
+redshirt-syscalls-interface = { path = "../../interfaces/syscalls", default-features = false }
 redshirt-wasi-hosted = { path = "../hosted-wasi" }
 spin = "0.5.2"
 

--- a/kernel/standalone/src/hardware.rs
+++ b/kernel/standalone/src/hardware.rs
@@ -24,8 +24,8 @@ use alloc::vec::Vec;
 use core::{convert::TryFrom as _, marker::PhantomData};
 use hashbrown::HashMap;
 use parity_scale_codec::{DecodeAll, Encode as _};
-use redshirt_core::scheduler::Pid;
 use redshirt_hardware_interface::ffi::{HardwareAccessResponse, HardwareMessage, Operation};
+use redshirt_syscalls_interface::Pid;
 use spin::Mutex;
 
 /// State machine for `hardware` interface messages handling.


### PR DESCRIPTION
`core` now depends on `syscalls-interface`.
`syscalls-interface` now contains `Pid`, `ThreadId` and `MessageId`.

I was hesitating between doing that and creating a new `primitives` crate.
I went for giving the role of "primitives container" to `syscalls-interface`.