### PR TITLE
Make IdPool lock-free again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,11 +851,13 @@ version = "0.1.0"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-interface-interface 0.1.0",
  "redshirt-loader-interface 0.1.0",
  "redshirt-syscalls-interface 0.1.0",
@@ -1309,6 +1320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 bs58 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 byteorder = { version = "1.3.2", default-features = false }
+crossbeam-queue = { version = "0.2.1", default-features = false, features = ["alloc"] }
 futures = { version = "0.3.1", default-features = false }      # TODO: necessary?
 hashbrown = { version = "0.6.0", default-features = false }
 redshirt-interface-interface = { path = "../interfaces/interface", default-features = false }
@@ -18,6 +19,7 @@ redshirt-threads-interface = { path = "../interfaces/threads", default-features 
 rand = { version = "0.7", default-features = false }
 rand_chacha = { version = "0.2.1", default-features = false }
 rand_core = { version = "0.5.0", default-features = false }
+rand_hc = { version = "0.2.0", default-features = false }
 sha2 = { version = "0.8.0", default-features = false }
 smallvec = { version = "1.0.0", default-features = false }
 spin = "0.5.2"

--- a/core/src/id_pool.rs
+++ b/core/src/id_pool.rs
@@ -14,9 +14,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use core::fmt;
+use crossbeam_queue::SegQueue;
 use rand::distributions::{Distribution as _, Uniform};
 use rand_chacha::{ChaCha20Core, ChaCha20Rng};
 use rand_core::SeedableRng as _;
+use rand_hc::Hc128Rng;
 use spin::Mutex;
 
 // Maths note: after 3 billion iterations, there's a 2% chance of a collision
@@ -26,26 +28,41 @@ use spin::Mutex;
 
 /// Lock-free pool of identifiers. Can assign new identifiers from it.
 pub struct IdPool {
-    /// Source of randomness.
-    // TODO: don't use a Mutex here unless necessary
-    rng: Mutex<ChaCha20Rng>,
+    /// Sources of randomness.
+    /// Every time we need a random number, we pop a state from this list, then push it back when
+    /// we're done.
+    rngs: SegQueue<ChaCha20Rng>,
     /// Distribution of IDs.
     distribution: Uniform<u64>,
+    /// RNG to seed other RNGs. We use a different algorithm than ChaCha in order to not clone
+    /// the ChaCha state when we derive from it.
+    // TODO: is it actually needed to have a different algorithm, or is this comment bullshit?
+    //       using a different algorithm doesn't hurt, but it'd be better if the comment was correct
+    master_rng: Mutex<Hc128Rng>,
 }
 
 impl IdPool {
     /// Initializes a new pool.
     pub fn new() -> Self {
         IdPool {
-            rng: Mutex::new(ChaCha20Rng::from_seed([0; 32])), // FIXME: proper seed
+            rngs: SegQueue::new(),
             distribution: Uniform::from(0..=u64::max_value()),
+            master_rng: Mutex::new(Hc128Rng::from_seed([0; 32])), // FIXME: proper seed
         }
     }
 
     /// Assigns a new PID from this pool.
     pub fn assign<T: From<u64>>(&self) -> T {
-        let mut rng = self.rng.lock();
-        let id = self.distribution.sample(&mut *rng);
+        if let Ok(mut rng) = self.rngs.pop() {
+            let id = self.distribution.sample(&mut rng);
+            self.rngs.push(rng);
+            return T::from(id);
+        }
+
+        let mut master_rng = self.master_rng.lock();
+        let mut new_rng = ChaCha20Rng::from_rng(&mut *master_rng).unwrap();
+        let id = self.distribution.sample(&mut new_rng);
+        self.rngs.push(new_rng);
         T::from(id)
     }
 }


### PR DESCRIPTION
Well, *almost* lock-free. It should only briefly locks once per thread at initialization.