### PR TITLE
Make syscalls non racy

### DIFF
--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -274,19 +274,19 @@ impl Core {
                 .with_extrinsic(
                     "redshirt",
                     "emit_message_error",
-                    sig!((I32) -> I32),
+                    sig!((I32)),
                     Extrinsic::EmitMessageError,
                 )
                 .with_extrinsic(
                     "redshirt",
                     "emit_answer",
-                    sig!((I32, I32, I32) -> I32),
+                    sig!((I32, I32, I32)),
                     Extrinsic::EmitAnswer,
                 )
                 .with_extrinsic(
                     "redshirt",
                     "cancel_message",
-                    sig!((I32) -> I32),
+                    sig!((I32)),
                     Extrinsic::CancelMessage,
                 ),
         }
@@ -568,7 +568,7 @@ impl Core {
                     EncodedMessage(thread.read_memory(addr, sz).unwrap())
                 };
                 let pid = thread.pid();
-                // TODO: we don't resume the thread that called the extrinsic
+                thread.resume(None);
                 self.answer_message_inner(msg_id, Ok(message))
                     .unwrap_or(CoreRunOutcomeInner::LoopAgain)
             }
@@ -589,11 +589,8 @@ impl Core {
                     MessageId::from(byteorder::LittleEndian::read_u64(&buf))
                 };
 
-                if let Some(_) = self.messages_to_answer.remove(&msg_id) {
-                    thread.resume(Some(wasmi::RuntimeValue::I32(0)));
-                } else {
-                    thread.resume(Some(wasmi::RuntimeValue::I32(1)));
-                }
+                self.messages_to_answer.remove(&msg_id);
+                thread.resume(None);
 
                 let pid = thread.pid();
                 self.answer_message_inner(msg_id, Err(()))

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -140,14 +140,8 @@ pub unsafe fn emit_message_with_response<'a, T: Decode>(
 }
 
 /// Cancel the given message. No answer will be received.
-pub fn cancel_message(message_id: MessageId) -> Result<(), CancelMessageErr> {
-    unsafe {
-        if crate::ffi::cancel_message(&u64::from(message_id)) == 0 {
-            Ok(())
-        } else {
-            Err(CancelMessageErr::InvalidMessageId)
-        }
-    }
+pub fn cancel_message(message_id: MessageId) {
+    unsafe { crate::ffi::cancel_message(&u64::from(message_id)) }
 }
 
 /// Error that can be retuend by functions that emit a message.
@@ -161,21 +155,6 @@ impl fmt::Display for EmitErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             EmitErr::BadInterface => write!(f, "The given interface has no handler"),
-        }
-    }
-}
-
-/// Error that can be retuend by [`cancel_message`].
-#[derive(Debug)]
-pub enum CancelMessageErr {
-    /// The message ID is not valid.
-    InvalidMessageId,
-}
-
-impl fmt::Display for CancelMessageErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            CancelMessageErr::InvalidMessageId => write!(f, "Invalid message ID"),
         }
     }
 }

--- a/interfaces/syscalls/src/ffi.rs
+++ b/interfaces/syscalls/src/ffi.rs
@@ -83,24 +83,20 @@ extern "C" {
 
     /// Sends an answer back to the emitter of given `message_id`.
     ///
-    /// Returns `0` on success, or `1` if there is no message with that id.
-    ///
     /// When this function is being called, a "lock" is being held on the memory pointed by
     /// `message_id` and `msg`. In particular, it is invalid to modify these buffers while the
     /// function is running.
-    pub(crate) fn emit_answer(message_id: *const u64, msg: *const u8, msg_len: u32) -> u32;
+    pub(crate) fn emit_answer(message_id: *const u64, msg: *const u8, msg_len: u32);
 
     /// Notifies the kernel that the given message is invalid and cannot reasonably be answered.
     ///
     /// This should be used in situations where a message we receive fails to parse or is generally
     /// invalid. In other words, this should only be used in case of misbehaviour by the sender.
     ///
-    /// Returns `0` on success, or `1` if there is no message with that id.
-    ///
     /// When this function is being called, a "lock" is being held on the memory pointed by
     /// `message_id`. In particular, it is invalid to modify these buffers while the function is
     /// running.
-    pub(crate) fn emit_message_error(message_id: *const u64) -> u32;
+    pub(crate) fn emit_message_error(message_id: *const u64);
 
     /// Cancel an expected answer.
     ///
@@ -110,12 +106,10 @@ extern "C" {
     ///
     /// After this function has been called, the passed `message_id` is no longer valid.
     ///
-    /// Returns `0` on success, or `1` if there is no message with that id.
-    ///
     /// When this function is being called, a "lock" is being held on the memory pointed by
     /// `message_id`. In particular, it is invalid to modify this buffer while the function is
     /// running.
-    pub(crate) fn cancel_message(message_id: *const u64) -> u32;
+    pub(crate) fn cancel_message(message_id: *const u64);
 }
 
 #[derive(Debug, Clone, Encode, Decode)]

--- a/interfaces/syscalls/src/interface_message.rs
+++ b/interfaces/syscalls/src/interface_message.rs
@@ -33,44 +33,17 @@ pub fn next_interface_message() -> InterfaceMessageFuture {
 
 /// Answers the given message.
 // TODO: move to interface interface?
-pub fn emit_answer(message_id: MessageId, msg: impl Encode) -> Result<(), EmitAnswerErr> {
+pub fn emit_answer(message_id: MessageId, msg: impl Encode) {
     unsafe {
         let buf = msg.encode();
-        let ret =
-            crate::ffi::emit_answer(&u64::from(message_id), buf.0.as_ptr(), buf.0.len() as u32);
-        if ret == 0 {
-            Ok(())
-        } else {
-            Err(EmitAnswerErr::InvalidMessageId)
-        }
+        crate::ffi::emit_answer(&u64::from(message_id), buf.0.as_ptr(), buf.0.len() as u32);
     }
 }
 
 /// Answers the given message by notifying of an error in the message.
 // TODO: move to interface interface?
-pub fn emit_message_error(message_id: MessageId) -> Result<(), EmitAnswerErr> {
-    unsafe {
-        if crate::ffi::emit_message_error(&u64::from(message_id)) == 0 {
-            Ok(())
-        } else {
-            Err(EmitAnswerErr::InvalidMessageId)
-        }
-    }
-}
-
-/// Error that can be retuend by [`emit_answer`].
-#[derive(Debug)]
-pub enum EmitAnswerErr {
-    /// The message ID is not valid or has already been answered.
-    InvalidMessageId,
-}
-
-impl fmt::Display for EmitAnswerErr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            EmitAnswerErr::InvalidMessageId => write!(f, "Invalid message ID"),
-        }
-    }
+pub fn emit_message_error(message_id: MessageId) {
+    unsafe { crate::ffi::emit_message_error(&u64::from(message_id)) }
 }
 
 /// Future that drives [`next_interface_message`] to completion.


### PR DESCRIPTION
Cancelling a message and emitting an answer are inherently racy operations.
One process could cancel its message while the other one emits an answer at the same time. When emitting an answer returns an error, it can simply mean that the message has been cancelled.

This removes the possibility for these functions to return errors.
