### PR TITLE
Make time-interface always no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
 name = "redshirt-time-interface"
 version = "0.1.0"
 dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-syscalls-interface 0.1.0",

--- a/interfaces/time/Cargo.toml
+++ b/interfaces/time/Cargo.toml
@@ -6,10 +6,7 @@ authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+futures = { version = "0.3.1", default-features = false, features = ["alloc"] }
 redshirt-syscalls-interface = { path = "../syscalls", default-features = false }
 parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive"] }
 pin-project = "0.4.6"
-
-[features]
-default = ["std"]
-std = []

--- a/interfaces/time/src/delay.rs
+++ b/interfaces/time/src/delay.rs
@@ -14,7 +14,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{monotonic_wait_until, Instant};
-use std::{fmt, future::Future, pin::Pin, task::Context, task::Poll, time::Duration};
+use alloc::boxed::Box;
+use core::{fmt, future::Future, pin::Pin, task::Context, task::Poll, time::Duration};
 
 /// Mimics the API of `futures_timer::Delay`.
 pub struct Delay {

--- a/interfaces/time/src/instant.rs
+++ b/interfaces/time/src/instant.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::monotonic_clock;
-use std::{convert::TryFrom, ops::Add, ops::Sub, time::Duration};
+use core::{convert::TryFrom, ops::Add, ops::Sub, time::Duration};
 
 /// Mimics the API of `std::time::Instant`, except that it works.
 ///

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -16,62 +16,57 @@
 //! Time.
 
 #![deny(intra_doc_link_resolution_failure)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+extern crate alloc;
 
 use core::time::Duration;
+use futures::prelude::*;
 
-#[cfg(feature = "std")]
 pub use self::delay::Delay;
-#[cfg(feature = "std")]
 pub use self::instant::Instant;
 
-#[cfg(feature = "std")]
 mod delay;
-pub mod ffi;
-#[cfg(feature = "std")]
 mod instant;
 
+pub mod ffi;
+
 /// Returns the number of nanoseconds since an arbitrary point in time in the past.
-#[cfg(feature = "std")]
-pub async fn monotonic_clock() -> u128 {
+pub fn monotonic_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetMonotonic;
         redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-            .await
-            .unwrap()
+            .map(|v| v.unwrap())
     }
 }
 
 /// Returns the number of nanoseconds since the Epoch (January 1st, 1970 at midnight UTC).
-#[cfg(feature = "std")]
-pub async fn system_clock() -> u128 {
+pub fn system_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetSystem;
         redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-            .await
-            .unwrap()
+            .map(|v| v.unwrap())
     }
 }
 
 /// Returns a `Future` that yields when the monotonic clock reaches this value.
-#[cfg(feature = "std")]
-pub async fn monotonic_wait_until(until: u128) {
+pub fn monotonic_wait_until(until: u128) -> impl Future<Output = ()> {
     unsafe {
         let msg = ffi::TimeMessage::WaitMonotonic(until);
         redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-            .await
-            .unwrap()
+            .map(|v| v.unwrap())
     }
 }
 
 /// Returns a `Future` that outputs after `duration` has elapsed.
-#[cfg(feature = "std")]
-pub async fn monotonic_wait(duration: Duration) {
+pub fn monotonic_wait(duration: Duration) -> impl Future<Output = ()> {
     let dur_nanos = u128::from(duration.as_secs())
         .saturating_mul(1_000_000_000)
         .saturating_add(u128::from(duration.subsec_nanos()));
 
     // TODO: meh for two syscalls
-    let now = monotonic_clock().await;
-    monotonic_wait_until(now.saturating_add(dur_nanos)).await;
+    monotonic_clock()
+        .then(move |now| {
+            monotonic_wait_until(now.saturating_add(dur_nanos))
+        })
 }

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -65,8 +65,5 @@ pub fn monotonic_wait(duration: Duration) -> impl Future<Output = ()> {
         .saturating_add(u128::from(duration.subsec_nanos()));
 
     // TODO: meh for two syscalls
-    monotonic_clock()
-        .then(move |now| {
-            monotonic_wait_until(now.saturating_add(dur_nanos))
-        })
+    monotonic_clock().then(move |now| monotonic_wait_until(now.saturating_add(dur_nanos)))
 }

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
 name = "redshirt-time-interface"
 version = "0.1.0"
 dependencies = [
+ "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-syscalls-interface 0.1.0",


### PR DESCRIPTION
Remove the `std` feature from `time-interface`.