### PR TITLE
Refactor emitting a message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +976,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1362,6 +1371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-util 0.3.1 (git+https://github.com/tomaka/futures-rs?branch=const-new-atomic-waker)" = "<none>"
 "checksum futures-util 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"

--- a/interfaces/hardware/src/lib.rs
+++ b/interfaces/hardware/src/lib.rs
@@ -215,9 +215,9 @@ impl<'a> HardwareOperationsBuilder<'a> {
         unsafe {
             let msg = ffi::HardwareMessage::HardwareAccess(self.operations);
             let out = self.out;
-            redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).then(
-                move |response| {
-                    let response: Vec<ffi::HardwareAccessResponse> = response.unwrap();
+            redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
+                .unwrap()
+                .then(move |response: Vec<ffi::HardwareAccessResponse>| {
                     for (response_elem, out) in response.into_iter().zip(out) {
                         match (response_elem, out) {
                             (ffi::HardwareAccessResponse::PortReadU8(val), Out::PortU8(out)) => {
@@ -246,8 +246,7 @@ impl<'a> HardwareOperationsBuilder<'a> {
                     }
 
                     future::ready(())
-                },
-            )
+                })
         }
     }
 }

--- a/interfaces/hardware/src/malloc.rs
+++ b/interfaces/hardware/src/malloc.rs
@@ -106,17 +106,16 @@ impl<T> PhysicalBuffer<T> {
                 len: u32::try_from(mem::size_of::<T>()).unwrap(),
             }]);
 
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).map(
-            move |response: Result<Vec<ffi::HardwareAccessResponse>, _>| {
-                let mut response = response.unwrap();
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
+            .unwrap()
+            .map(move |mut response: Vec<ffi::HardwareAccessResponse>| {
                 debug_assert_eq!(response.len(), 1);
                 let buf = match response.remove(0) {
                     ffi::HardwareAccessResponse::PhysicalMemoryReadU8(val) => val,
                     _ => unreachable!(),
                 };
                 ptr::read_unaligned(buf.as_ptr() as *const T)
-            },
-        )
+            })
     }
 }
 
@@ -135,14 +134,13 @@ impl<T: ?Sized> Drop for PhysicalBuffer<T> {
 pub fn malloc(size: u64, alignment: u8) -> impl Future<Output = u64> {
     unsafe {
         let msg = ffi::HardwareMessage::Malloc { size, alignment };
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).map(
-            move |out: Result<u64, _>| {
-                let ptr = out.unwrap();
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
+            .unwrap()
+            .map(move |ptr: u64| {
                 assert_ne!(ptr, 0);
                 debug_assert_eq!(ptr % u64::from(alignment), 0);
                 ptr
-            },
-        )
+            })
     }
 }
 

--- a/interfaces/interface/src/lib.rs
+++ b/interfaces/interface/src/lib.rs
@@ -37,7 +37,8 @@ pub fn register_interface(
     let msg = ffi::InterfaceMessage::Register(hash);
     // TODO: we unwrap cause there's always something that handles interface registration; is that correct?
     unsafe {
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
-            .map(|response: Result<ffi::InterfaceRegisterResponse, _>| response.unwrap().result)
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
+            .unwrap()
+            .map(|response: ffi::InterfaceRegisterResponse| response.result)
     }
 }

--- a/interfaces/loader/src/lib.rs
+++ b/interfaces/loader/src/lib.rs
@@ -35,11 +35,9 @@ pub mod ffi;
 pub fn load(hash: [u8; 32]) -> impl Future<Output = Result<Vec<u8>, ()>> {
     unsafe {
         let msg = ffi::LoaderMessage::Load(hash);
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg).map(
-            |rep: Result<ffi::LoadResponse, _>| match rep {
-                Ok(rep) => rep.result,
-                Err(_) => Err(()),
-            },
-        )
+        match redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg) {
+            Ok(fut) => fut.map(|rep: ffi::LoadResponse| rep.result).left_future(),
+            Err(_) => future::ready(Err(())).right_future(),
+        }
     }
 }

--- a/interfaces/random/src/lib.rs
+++ b/interfaces/random/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn generate_in(out: &mut [u8]) {
             len: u16::try_from(chunk.len()).unwrap(),
         };
         let rep: ffi::GenerateResponse = unsafe {
-            redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+            redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
                 .await
                 .unwrap()
         };

--- a/interfaces/random/src/lib.rs
+++ b/interfaces/random/src/lib.rs
@@ -44,8 +44,8 @@ pub async fn generate_in(out: &mut [u8]) {
         };
         let rep: ffi::GenerateResponse = unsafe {
             redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
-                .await
                 .unwrap()
+                .await
         };
         chunk.copy_from_slice(&rep.result);
     }

--- a/interfaces/stdout/src/lib.rs
+++ b/interfaces/stdout/src/lib.rs
@@ -33,6 +33,6 @@ pub mod ffi;
 pub fn stdout(msg: String) {
     unsafe {
         let msg = ffi::StdoutMessage::Message(msg);
-        redshirt_syscalls_interface::emit_message(&ffi::INTERFACE, &msg, false).unwrap();
+        redshirt_syscalls_interface::emit_message_without_response(&ffi::INTERFACE, &msg).unwrap();
     }
 }

--- a/interfaces/syscalls/Cargo.toml
+++ b/interfaces/syscalls/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 byteorder = { version = "1.3.2", default-features = false }
 futures = { version = "0.3.1", default-features = false, features = ["alloc"] }
+generic-array = { version = "0.13.2", default-features = false }
 hashbrown = { version = "0.6.0", default-features = false, features = ["ahash"] }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive"] }

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -13,40 +13,162 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Decode, Encode, InterfaceHash, MessageId};
+use crate::{Decode, Encode, EncodedMessage, InterfaceHash, MessageId};
 use byteorder::{ByteOrder as _, LittleEndian};
 use core::{
     convert::TryFrom as _,
     fmt,
+    marker::PhantomData,
     mem::MaybeUninit,
     pin::Pin,
     task::{Context, Poll},
 };
 use futures::prelude::*;
+use generic_array::{
+    sequence::Concat as _,
+    typenum::consts::{U0, U8},
+    ArrayLength, GenericArray,
+};
 
-/// Emits a message destined to the handler of the given interface.
+/// Prototype for a message in construction.
 ///
-/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
-/// is available for that interface.
-/// Whether this function succeeds only depends on whether an interface handler is available. This
-/// function doesn't perform any validity check on the message itself.
-///
-/// If `needs_answer` is true, then we expect an answer to the message to come later. A message ID
-/// is generated and is returned within `Ok(Some(...))`.
-/// If `needs_answer` is false, the function always returns `Ok(None)`.
-///
-/// # Safety
-///
-/// While the action of sending a message is totally safe, the message itself might instruct the
-/// environment to perform actions that would lead to unsafety.
-///
-pub unsafe fn emit_message<'a>(
-    interface_hash: &InterfaceHash,
-    msg: impl Encode,
-    needs_answer: bool,
-) -> Result<Option<MessageId>, EmitErr> {
-    let encoded = msg.encode();
-    emit_message_raw(interface_hash, &encoded.0, needs_answer).map(|r| r.map(MessageId::from))
+/// Use this struct if you want to send out a message split between multiple slices.
+pub struct MessageBuilder<'a, TLen: ArrayLength<u8>> {
+    /// Parameter for the FFI function.
+    allow_delay: bool,
+    /// Array of slices, passed to the FFI function.
+    array: GenericArray<u8, TLen>,
+    /// Pin the lifetime. The lifetime corresponds to the lifetime of buffers pointer to
+    /// within `array`.
+    marker: PhantomData<&'a ()>,
+}
+
+impl<'a> MessageBuilder<'a, U0> {
+    /// Start building an empty message.
+    pub fn new() -> Self {
+        MessageBuilder {
+            allow_delay: true,
+            array: Default::default(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, TLen> MessageBuilder<'a, TLen>
+where
+    TLen: ArrayLength<u8>,
+{
+    /// If called, emitting the message will fail if no interface handler is available. Otherwise,
+    /// emitting the message will block the thread until a handler is available.
+    pub fn with_no_delay(mut self) -> Self {
+        self.allow_delay = false;
+        self
+    }
+
+    /// Append a slice of message data to the builder.
+    ///
+    /// > **Note**: This operation is cheap and doesn't perform any copy of the message data
+    /// >           itself.
+    pub fn add_data<TOutLen>(self, buffer: &'a EncodedMessage) -> MessageBuilder<'a, TOutLen>
+    where
+        TLen: core::ops::Add<U8, Output = TOutLen>,
+        TOutLen: ArrayLength<u8>,
+    {
+        let mut new_pair = GenericArray::<u8, U8>::default();
+        LittleEndian::write_u32(
+            &mut new_pair[0..4],
+            u32::try_from(buffer.0.as_ptr() as usize).unwrap(),
+        );
+        LittleEndian::write_u32(&mut new_pair[4..8], u32::try_from(buffer.0.len()).unwrap());
+
+        MessageBuilder {
+            allow_delay: self.allow_delay,
+            array: self.array.concat(new_pair),
+            marker: self.marker,
+        }
+    }
+
+    /// Emit the message and returns a `Future` that will yield the response.
+    // TODO: could we remove the error type?
+    pub unsafe fn emit_with_response<T>(
+        self,
+        interface: &InterfaceHash,
+    ) -> Result<impl Future<Output = T>, EmitErr>
+    where
+        T: Decode,
+    {
+        let msg_id = self.emit_with_response_raw(interface)?;
+        let response_fut = crate::message_response(msg_id);
+        Ok(EmitMessageWithResponse {
+            inner: Some(response_fut),
+            msg_id,
+        })
+    }
+
+    /// Emit the message and returns the emitted [`MessageId`].
+    // TODO: could we remove the error type?
+    pub unsafe fn emit_with_response_raw(
+        self,
+        interface: &InterfaceHash,
+    ) -> Result<MessageId, EmitErr> {
+        Ok(self.emit_raw(interface, true)?.unwrap())
+    }
+
+    /// Emit the message. The message doesn't expect any response. If the handler tries to
+    /// respond, the response will be ignored.
+    // TODO: could we remove the error type?
+    pub unsafe fn emit_without_response(self, interface: &InterfaceHash) -> Result<(), EmitErr> {
+        let out = self.emit_raw(interface, false)?;
+        debug_assert!(out.is_none());
+        Ok(())
+    }
+
+    /// Emit the message. You can decide at runtime whether or not the message expects a response.
+    ///
+    /// If `needs_answer` is `true`, then on success a `Some` will always be returned.
+    /// If `needs_answer` is `false`, then on success a `None` will always be returned.
+    // TODO: could we remove the error type?
+    pub unsafe fn emit_raw(
+        self,
+        interface: &InterfaceHash,
+        needs_answer: bool,
+    ) -> Result<Option<MessageId>, EmitErr> {
+        let mut message_id_out = MaybeUninit::uninit();
+
+        let ret = crate::ffi::emit_message(
+            interface as *const InterfaceHash as *const _,
+            self.array.as_ptr(),
+            u32::try_from(self.array.len() / 4).unwrap(),
+            needs_answer,
+            self.allow_delay,
+            message_id_out.as_mut_ptr(),
+        );
+
+        if ret != 0 {
+            return Err(EmitErr::BadInterface);
+        }
+
+        if needs_answer {
+            Ok(Some(MessageId::from(message_id_out.assume_init())))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl<'a> Default for MessageBuilder<'a, U0> {
+    fn default() -> Self {
+        MessageBuilder::new()
+    }
+}
+
+impl<'a, TLen> fmt::Debug for MessageBuilder<'a, TLen>
+where
+    TLen: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("MessageBuilder").finish()
+    }
 }
 
 /// Emits a message destined to the handler of the given interface.
@@ -62,61 +184,13 @@ pub unsafe fn emit_message<'a>(
 /// environment to perform actions that would lead to unsafety.
 ///
 pub unsafe fn emit_message_without_response<'a>(
-    interface_hash: &InterfaceHash,
+    interface: &InterfaceHash,
     msg: impl Encode,
 ) -> Result<(), EmitErr> {
-    emit_message(interface_hash, msg, false)?;
-    Ok(())
-}
-
-/// Emits a message destined to the handler of the given interface.
-///
-/// Returns `Ok` if the message has been successfully dispatched. Returns an error if no handler
-/// is available for that interface.
-/// Whether this function succeeds only depends on whether an interface handler is available. This
-/// function doesn't perform any validity check on the message itself.
-///
-/// If `needs_answer` is true, then we expect an answer to the message to come later. A message ID
-/// is generated and is returned within `Ok(Some(...))`.
-/// If `needs_answer` is false, the function always returns `Ok(None)`.
-///
-/// # Safety
-///
-/// While the action of sending a message is totally safe, the message itself might instruct the
-/// environment to perform actions that would lead to unsafety.
-///
-pub unsafe fn emit_message_raw(
-    interface_hash: &InterfaceHash,
-    buf: &[u8],
-    needs_answer: bool,
-) -> Result<Option<MessageId>, EmitErr> {
-    let mut message_id_out = MaybeUninit::uninit();
-
-    let mut slice = [0u8; 8];
-    LittleEndian::write_u32(
-        &mut slice[0..4],
-        u32::try_from(buf.as_ptr() as usize).unwrap(),
-    );
-    LittleEndian::write_u32(&mut slice[4..8], u32::try_from(buf.len()).unwrap());
-
-    let ret = crate::ffi::emit_message(
-        interface_hash as *const InterfaceHash as *const _,
-        slice.as_ptr(),
-        1,
-        needs_answer,
-        true,
-        message_id_out.as_mut_ptr(),
-    );
-
-    if ret != 0 {
-        return Err(EmitErr::BadInterface);
-    }
-
-    if needs_answer {
-        Ok(Some(MessageId::from(message_id_out.assume_init())))
-    } else {
-        Ok(None)
-    }
+    let msg = msg.encode();
+    MessageBuilder::new()
+        .add_data(&msg)
+        .emit_without_response(interface)
 }
 
 /// Emis a message, then waits for a response to come back.
@@ -134,21 +208,18 @@ pub unsafe fn emit_message_raw(
 /// environment to perform actions that would lead to unsafety.
 ///
 pub unsafe fn emit_message_with_response<'a, T: Decode>(
-    interface_hash: InterfaceHash,
+    interface: &InterfaceHash,
     msg: impl Encode,
-) -> impl Future<Output = Result<T, EmitErr>> {
-    let msg_id = match emit_message(&interface_hash, msg, true) {
-        Ok(m) => m.unwrap(),
-        Err(err) => return future::Either::Right(future::ready(Err(err))),
-    };
-    let response_fut = crate::message_response(msg_id);
-    future::Either::Left(EmitMessageWithResponse {
-        inner: Some(response_fut),
-        msg_id,
-    })
+) -> Result<impl Future<Output = T>, EmitErr> {
+    let msg = msg.encode();
+    MessageBuilder::new()
+        .add_data(&msg)
+        .emit_with_response(interface)
 }
 
 /// Cancel the given message. No answer will be received.
+///
+/// Has no effect if the message is invalid.
 pub fn cancel_message(message_id: MessageId) {
     unsafe { crate::ffi::cancel_message(&u64::from(message_id)) }
 }
@@ -179,7 +250,7 @@ pub struct EmitMessageWithResponse<T> {
 }
 
 impl<T: Decode> Future for EmitMessageWithResponse<T> {
-    type Output = Result<T, EmitErr>;
+    type Output = T;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         unsafe {
@@ -194,7 +265,7 @@ impl<T: Decode> Future for EmitMessageWithResponse<T> {
                 Poll::Pending => return Poll::Pending,
             };
             *this.inner = None;
-            Poll::Ready(Ok(val))
+            Poll::Ready(val)
         }
     }
 }

--- a/interfaces/syscalls/src/lib.rs
+++ b/interfaces/syscalls/src/lib.rs
@@ -86,8 +86,7 @@ extern crate alloc;
 
 pub use block_on::block_on;
 pub use emit::{
-    cancel_message, emit_message, emit_message_raw, emit_message_with_response,
-    emit_message_without_response,
+    cancel_message, emit_message_with_response, emit_message_without_response, MessageBuilder,
 };
 pub use ffi::{InterfaceMessage, InterfaceOrDestroyed, Message, ResponseMessage};
 pub use interface_message::{

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -35,7 +35,7 @@ pub mod ffi;
 pub fn monotonic_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetMonotonic;
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
             .map(|v| v.unwrap())
     }
 }
@@ -44,7 +44,7 @@ pub fn monotonic_clock() -> impl Future<Output = u128> {
 pub fn system_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetSystem;
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
             .map(|v| v.unwrap())
     }
 }
@@ -53,7 +53,7 @@ pub fn system_clock() -> impl Future<Output = u128> {
 pub fn monotonic_wait_until(until: u128) -> impl Future<Output = ()> {
     unsafe {
         let msg = ffi::TimeMessage::WaitMonotonic(until);
-        redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, msg)
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
             .map(|v| v.unwrap())
     }
 }

--- a/interfaces/time/src/lib.rs
+++ b/interfaces/time/src/lib.rs
@@ -35,8 +35,7 @@ pub mod ffi;
 pub fn monotonic_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetMonotonic;
-        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
-            .map(|v| v.unwrap())
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg).unwrap()
     }
 }
 
@@ -44,8 +43,7 @@ pub fn monotonic_clock() -> impl Future<Output = u128> {
 pub fn system_clock() -> impl Future<Output = u128> {
     unsafe {
         let msg = ffi::TimeMessage::GetSystem;
-        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
-            .map(|v| v.unwrap())
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg).unwrap()
     }
 }
 
@@ -53,8 +51,7 @@ pub fn system_clock() -> impl Future<Output = u128> {
 pub fn monotonic_wait_until(until: u128) -> impl Future<Output = ()> {
     unsafe {
         let msg = ffi::TimeMessage::WaitMonotonic(until);
-        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg)
-            .map(|v| v.unwrap())
+        redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, msg).unwrap()
     }
 }
 

--- a/interfaces/vulkan/build/main.rs
+++ b/interfaces/vulkan/build/main.rs
@@ -182,7 +182,7 @@ fn write_commands_wrappers(mut out: impl Write, registry: &parse::VkRegistry) {
             );
         }
 
-        writeln!(out, "    let msg_id = redshirt_syscalls_interface::emit_message_raw(&INTERFACE, &msg_buf, true).unwrap().unwrap();").unwrap();
+        writeln!(out, "    let msg_id = redshirt_syscalls_interface::MessageBuilder::new().add_data(&redshirt_syscalls_interface::EncodedMessage(msg_buf)).emit_with_response_raw(&INTERFACE).unwrap();").unwrap();
         writeln!(
             out,
             "    let response = redshirt_syscalls_interface::message_response_sync_raw(msg_id);"

--- a/interfaces/window/src/lib.rs
+++ b/interfaces/window/src/lib.rs
@@ -29,7 +29,7 @@ impl Window {
     pub async fn open() -> Result<Window, ()> {
         let open = ffi::WindowMessage::Open(ffi::WindowOpen {});
         let response: ffi::WindowOpenResponse = unsafe {
-            redshirt_syscalls_interface::emit_message_with_response(ffi::INTERFACE, open)
+            redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, open)
                 .await
                 .map_err(|_| ())?
         };

--- a/interfaces/window/src/lib.rs
+++ b/interfaces/window/src/lib.rs
@@ -30,8 +30,8 @@ impl Window {
         let open = ffi::WindowMessage::Open(ffi::WindowOpen {});
         let response: ffi::WindowOpenResponse = unsafe {
             redshirt_syscalls_interface::emit_message_with_response(&ffi::INTERFACE, open)
-                .await
                 .map_err(|_| ())?
+                .await
         };
         Ok(Window {
             handle: response.result?,
@@ -46,7 +46,8 @@ impl Drop for Window {
                 window_id: self.handle,
             });
 
-            let _ = redshirt_syscalls_interface::emit_message(&ffi::INTERFACE, &close, false);
+            let _ =
+                redshirt_syscalls_interface::emit_message_without_response(&ffi::INTERFACE, &close);
         }
     }
 }

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -552,6 +552,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1338,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2052,6 +2061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "5ce968633c17e5f97936bd2797b6e38fb56cf16a7422319f7ec2e30d3c470e8d"
 "checksum futures_codec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8efb8edac092482013e203af800eef158349c8bbf461edff59c5dd2d3c00e87"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+"checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f107db1419ef8271686187b1a5d47c6431af4a7f4d98b495e7b7fc249bb0a78"
 "checksum half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ff54597ea139063f4225f1ec47011b03c9de4a486957ff3fc506881dac951d0"


### PR DESCRIPTION
After #179, cleans up a bit the API of emitting a message in `syscalls` and allows sending messages split between slices.