### PR TITLE
Remove lots of unwraps in core & kernel

### DIFF
--- a/core/src/id_pool.rs
+++ b/core/src/id_pool.rs
@@ -60,7 +60,10 @@ impl IdPool {
         }
 
         let mut master_rng = self.master_rng.lock();
-        let mut new_rng = ChaCha20Rng::from_rng(&mut *master_rng).unwrap();
+        let mut new_rng = match ChaCha20Rng::from_rng(&mut *master_rng) {
+            Ok(r) => r,
+            Err(_) => unreachable!(),
+        };
         let id = self.distribution.sample(&mut new_rng);
         self.rngs.push(new_rng);
         T::from(id)

--- a/core/src/native/collection.rs
+++ b/core/src/native/collection.rs
@@ -313,7 +313,10 @@ where
     T: NativeProgramMessageIdWrite,
 {
     fn acknowledge(&mut self, id: MessageId) {
-        self.inner.take().unwrap().acknowledge(id);
+        match self.inner.take() {
+            Some(inner) => inner.acknowledge(id),
+            None => unreachable!(),
+        };
         let _was_inserted = self.expected_responses.lock().insert(id);
         debug_assert!(_was_inserted);
     }

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -316,7 +316,10 @@ impl Core {
                 CoreRunOutcomeInner::ThreadWaitUnavailableInterface { thread, interface } => {
                     CoreRunOutcome::ThreadWaitUnavailableInterface {
                         thread: CoreThread {
-                            thread: self.processes.thread_by_id(thread).unwrap(),
+                            thread: match self.processes.thread_by_id(thread) {
+                                Some(t) => t,
+                                None => unreachable!(),
+                            },
                         },
                         interface,
                     }
@@ -512,7 +515,10 @@ impl Core {
                                 },
                             );
 
-                            let mut process = self.processes.process_by_id(*pid).unwrap();
+                            let mut process = match self.processes.process_by_id(*pid) {
+                                Some(p) => p,
+                                None => unreachable!(),
+                            };
                             process.user_data().messages_queue.push_back(message);
                             try_resume_message_wait(process);
                             CoreRunOutcomeInner::LoopAgain
@@ -680,17 +686,18 @@ impl Core {
                 },
             );
 
-            self.processes
-                .process_by_id(process)
-                .unwrap()
-                .user_data()
-                .messages_queue
-                .push_back(message);
+            match self.processes.process_by_id(process) {
+                Some(mut p) => p.user_data().messages_queue.push_back(message),
+                None => unreachable!(),
+            }
         }
 
         // Now process the threads that were waiting for this interface to be registered.
         for thread_id in thread_ids {
-            let mut thread = self.processes.thread_by_id(thread_id).unwrap();
+            let mut thread = match self.processes.thread_by_id(thread_id) {
+                Some(t) => t,
+                None => unreachable!(),
+            };
             let thread_user_data = mem::replace(thread.user_data(), Thread::ReadyToRun);
             if let Thread::InterfaceNotAvailableWait {
                 interface: int,
@@ -766,8 +773,10 @@ impl Core {
         message: impl Encode,
     ) -> MessageId {
         assert!(self.reserved_pids.contains(&emitter_pid));
-        self.emit_interface_message_inner(emitter_pid, interface, message, true)
-            .unwrap()
+        match self.emit_interface_message_inner(emitter_pid, interface, message, true) {
+            Some(m) => m,
+            None => unreachable!(),
+        }
     }
 
     fn emit_interface_message_inner<'a>(
@@ -1100,13 +1109,15 @@ fn try_resume_message_wait_thread(
     // TODO: don't use as
     if msg_wait.out_size as usize >= msg_bytes.0.len() {
         // Write the message in the process's memory.
-        thread
-            .write_memory(msg_wait.out_pointer, &msg_bytes.0)
-            .unwrap();
+        match thread.write_memory(msg_wait.out_pointer, &msg_bytes.0) {
+            Ok(()) => {}
+            Err(_) => panic!(),
+        };
         // Zero the corresponding entry in the messages to wait upon.
-        thread
-            .write_memory(msg_wait.msg_ids_ptr + index_in_msg_ids * 8, &[0; 8])
-            .unwrap();
+        match thread.write_memory(msg_wait.msg_ids_ptr + index_in_msg_ids * 8, &[0; 8]) {
+            Ok(()) => {}
+            Err(_) => panic!(),
+        };
         // Pop the message from the queue, so that we don't deliver it twice.
         thread
             .process_user_data()

--- a/core/src/scheduler/vm.rs
+++ b/core/src/scheduler/vm.rs
@@ -385,7 +385,11 @@ impl<T> ProcessStateMachine<T> {
             .and_then(|f| f)
             .ok_or(StartErr::FunctionNotFound)?;
 
-        let execution = wasmi::FuncInstance::invoke_resumable(&function, params).unwrap();
+        let execution = match wasmi::FuncInstance::invoke_resumable(&function, params) {
+            Ok(e) => e,
+            Err(err) => unreachable!("{:?}", err),
+        };
+
         self.threads.push(ThreadState {
             execution: Some(execution),
             interrupted: false,
@@ -413,7 +417,10 @@ impl<T> ProcessStateMachine<T> {
 
         match self.module.export_by_name(symbol_name) {
             Some(wasmi::ExternVal::Func(f)) => {
-                let execution = wasmi::FuncInstance::invoke_resumable(&f, params).unwrap();
+                let execution = match wasmi::FuncInstance::invoke_resumable(&f, params) {
+                    Ok(e) => e,
+                    Err(err) => unreachable!("{:?}", err),
+                };
                 self.threads.push(ThreadState {
                     execution: Some(execution),
                     interrupted: false,
@@ -462,10 +469,12 @@ impl<T> ProcessStateMachine<T> {
     ///
     /// Returns an error if the range is invalid or out of range.
     pub fn read_memory(&self, offset: u32, size: u32) -> Result<Vec<u8>, ()> {
-        self.memory
-            .as_ref()
-            .unwrap()
-            .get(offset, size.try_into().map_err(|_| ())?)
+        let mem = match self.memory.as_ref() {
+            Some(m) => m,
+            None => unreachable!(),
+        };
+
+        mem.get(offset, size.try_into().map_err(|_| ())?)
             .map_err(|_| ())
     }
 
@@ -473,11 +482,12 @@ impl<T> ProcessStateMachine<T> {
     ///
     /// Returns an error if the range is invalid or out of range.
     pub fn write_memory(&mut self, offset: u32, value: &[u8]) -> Result<(), ()> {
-        self.memory
-            .as_ref()
-            .unwrap()
-            .set(offset, value)
-            .map_err(|_| ())
+        let mem = match self.memory.as_ref() {
+            Some(m) => m,
+            None => unreachable!(),
+        };
+
+        mem.set(offset, value).map_err(|_| ())
     }
 }
 
@@ -540,7 +550,10 @@ impl<'a, T> Thread<'a, T> {
 
         let thread_state = &mut self.vm.threads[self.index];
 
-        let mut execution = thread_state.execution.take().unwrap();
+        let mut execution = match thread_state.execution.take() {
+            Some(e) => e,
+            None => unreachable!(),
+        };
         let result = if thread_state.interrupted {
             let expected_ty = execution.resumable_value_type();
             let obtained_ty = value.as_ref().map(|v| v.value_type());
@@ -579,7 +592,10 @@ impl<'a, T> Thread<'a, T> {
             Err(wasmi::ResumableError::NotResumable) => unreachable!(),
             Err(wasmi::ResumableError::Trap(ref trap)) if trap.kind().is_host() => {
                 let interrupt: &Interrupt = match trap.kind() {
-                    wasmi::TrapKind::Host(err) => err.downcast_ref().unwrap(),
+                    wasmi::TrapKind::Host(err) => match err.downcast_ref() {
+                        Some(e) => e,
+                        None => unreachable!(),
+                    },
                     _ => unreachable!(),
                 };
                 thread_state.execution = Some(execution);

--- a/kernel/standalone/src/hardware.rs
+++ b/kernel/standalone/src/hardware.rs
@@ -109,9 +109,16 @@ impl<'a> NativeProgramRef<'a> for &'a HardwareHandler {
             }
             Ok(HardwareMessage::Malloc { size, alignment }) => {
                 // TODO: this is obviously badly written
+                let size = match usize::try_from(size) {
+                    Ok(s) => s,
+                    Err(_) => panic!()
+                };
                 let buffer =
-                    Vec::with_capacity(usize::try_from(size).unwrap() + usize::from(alignment) - 1);
-                let mut ptr = u64::try_from(buffer.as_ptr() as usize).unwrap();
+                    Vec::with_capacity(size + usize::from(alignment) - 1);
+                let mut ptr = match u64::try_from(buffer.as_ptr() as usize) {
+                    Ok(p) => p,
+                    Err(_) => panic!()
+                };
                 while ptr % u64::from(alignment) != 0 {
                     ptr += 1;
                 }

--- a/kernel/standalone/src/hardware.rs
+++ b/kernel/standalone/src/hardware.rs
@@ -111,13 +111,12 @@ impl<'a> NativeProgramRef<'a> for &'a HardwareHandler {
                 // TODO: this is obviously badly written
                 let size = match usize::try_from(size) {
                     Ok(s) => s,
-                    Err(_) => panic!()
+                    Err(_) => panic!(),
                 };
-                let buffer =
-                    Vec::with_capacity(size + usize::from(alignment) - 1);
+                let buffer = Vec::with_capacity(size + usize::from(alignment) - 1);
                 let mut ptr = match u64::try_from(buffer.as_ptr() as usize) {
                     Ok(p) => p,
-                    Err(_) => panic!()
+                    Err(_) => panic!(),
                 };
                 while ptr % u64::from(alignment) != 0 {
                     ptr += 1;

--- a/kernel/standalone/src/random/rng.rs
+++ b/kernel/standalone/src/random/rng.rs
@@ -67,7 +67,10 @@ impl KernelRng {
 
             // This makes sure that the `JitterRng` is good enough. A panic here indicates that
             // our entropy would be too low.
-            let rounds = rng.test_timer().unwrap();
+            let rounds = match rng.test_timer() {
+                Ok(r) => r,
+                Err(err) => panic!("{:?}", err)
+            };
             rng.set_rounds(rounds);
             // According to the documentation, we have to discard the first `u64`.
             let _ = rng.next_u64();

--- a/kernel/standalone/src/random/rng.rs
+++ b/kernel/standalone/src/random/rng.rs
@@ -69,7 +69,7 @@ impl KernelRng {
             // our entropy would be too low.
             let rounds = match rng.test_timer() {
                 Ok(r) => r,
-                Err(err) => panic!("{:?}", err)
+                Err(err) => panic!("{:?}", err),
             };
             rng.set_rounds(rounds);
             // According to the documentation, we have to discard the first `u64`.


### PR DESCRIPTION
We don't have backtraces in this freestanding environment, meaning that it is extremely annoying to get a kernel panic in `Result::unwrap` or `Option::unwrap`.
I think it's a good idea to manually call `panic!` for now.