### PR TITLE
Split ipc.rs in two

### DIFF
--- a/core/src/scheduler.rs
+++ b/core/src/scheduler.rs
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+mod extrinsics;
 mod ipc;
 mod processes;
 mod tests;

--- a/core/src/scheduler/extrinsics.rs
+++ b/core/src/scheduler/extrinsics.rs
@@ -1,0 +1,823 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::id_pool::IdPool;
+use crate::module::Module;
+use crate::scheduler::{processes, vm};
+use crate::sig;
+use crate::signature::Signature;
+use crate::{InterfaceHash, MessageId};
+
+use alloc::{borrow::Cow, vec, vec::Vec};
+use byteorder::{ByteOrder as _, LittleEndian};
+use core::fmt;
+use hashbrown::{
+    hash_map::{DefaultHashBuilder, Entry, OccupiedEntry},
+    HashMap,
+};
+use redshirt_syscalls_interface::{EncodedMessage, Pid, ThreadId};
+
+/// Wrapper around [`ProcessesCollection`](processes::ProcessesCollection), but that interprets
+/// the extrinsic calls and keeps track of the state in which threads are waiting.
+///
+/// The generic parameters `TPud` and `TTud` are "user data"s that are stored respectively per
+/// process and per thread, and allows the user to put extra information associated to a process
+/// or a thread.
+pub struct ProcessesCollectionExtrinsics<TPud, TTud> {
+    inner: processes::ProcessesCollection<Extrinsic, TPud, LocalThreadUserData<TTud>>,
+}
+
+/// Prototype for a `ProcessesCollectionExtrinsics` under construction.
+pub struct ProcessesCollectionExtrinsicsBuilder {
+    inner: processes::ProcessesCollectionBuilder<Extrinsic>,
+}
+
+/// Access to a process within the collection.
+pub struct ProcessesCollectionExtrinsicsProc<'a, TPud, TTud> {
+    inner: processes::ProcessesCollectionProc<'a, TPud, LocalThreadUserData<TTud>>,
+}
+
+/// Access to a thread within the collection.
+pub enum ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+    Regular(ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud>),
+    EmitMessage(ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud>),
+    WaitMessage(ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud>),
+}
+
+/// Access to a thread within the collection.
+pub struct ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud> {
+    inner: processes::ProcessesCollectionThread<'a, TPud, LocalThreadUserData<TTud>>,
+}
+
+/// Access to a thread within the collection.
+pub struct ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud> {
+    inner: processes::ProcessesCollectionThread<'a, TPud, LocalThreadUserData<TTud>>,
+}
+
+/// Access to a thread within the collection.
+pub struct ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud> {
+    inner: processes::ProcessesCollectionThread<'a, TPud, LocalThreadUserData<TTud>>,
+}
+
+pub trait ProcessesCollectionExtrinsicsThreadAccess {
+    type ProcessUserData;
+    type ThreadUserData;
+
+    /// Returns the id of the thread. Allows later retrieval by calling
+    /// [`thread_by_id`](ProcessesCollectionExtrinsics::thread_by_id).
+    ///
+    /// [`ThreadId`]s are unique within a [`ProcessesCollectionExtrinsics`], independently from the
+    /// process.
+    fn tid(&mut self) -> ThreadId;
+
+    /// Returns the [`Pid`] of the process. Allows later retrieval by calling
+    /// [`process_by_id`](ProcessesCollectionExtrinsics::process_by_id).
+    fn pid(&self) -> Pid;
+
+    /*/// Returns the following thread within the next process, or `None` if this is the last thread.
+    ///
+    /// Threads are ordered arbitrarily. In particular, they are **not** ordered by [`ThreadId`].
+    fn next_thread(mut self) -> Option<ProcessesCollectionExtrinsicsThread<'a, TPud, TTud>> {
+        self.thread_index += 1;
+        if self.thread_index >= self.process.get_mut().state_machine.num_threads() {
+            return None;
+        }
+
+        Some(self)
+    }*/
+
+    /// Returns the user data that is associated to the process.
+    fn process_user_data(&mut self) -> &mut Self::ProcessUserData;
+
+    /// Returns the user data that is associated to the thread.
+    fn user_data(&mut self) -> &mut Self::ThreadUserData;
+}
+
+/// How a process is waiting for messages.
+#[derive(Debug, PartialEq, Eq)]
+struct MessageWait {
+    /// Identifiers of the messages we are waiting upon. Copy of what is in the process's memory.
+    msg_ids: Vec<MessageId>,
+    /// Offset within the memory of the process where the list of messages to wait upon is
+    /// located. This is necessary as we have to zero.
+    msg_ids_ptr: u32,
+    /// Offset within the memory of the process where to write the received message.
+    out_pointer: u32,
+    /// Size of the memory of the process dedicated to receiving the message.
+    out_size: u32,
+    /// Whether to block the thread if no message is available.
+    block: bool,
+}
+
+/// How a process is emitting a message.
+#[derive(Debug, PartialEq, Eq)]
+struct EmitMessage {
+    /// Interface we want to emit the message on.
+    interface: InterfaceHash,
+    /// Where to write back the message ID, or `None` if no answer is expected.
+    message_id_write: Option<u32>,
+    /// Message itself. Needs to be delivered to the handler once it is registered.
+    message: EncodedMessage,
+    /// True if we're allowed to block the thread to wait for an interface handler to be
+    /// available.
+    allow_delay: bool,
+}
+
+/// How a process is emitting a response.
+#[derive(Debug, PartialEq, Eq)]
+struct EmitAnswer {
+    /// Message to answer.
+    message_id: u32,
+    /// The response itself.
+    response: EncodedMessage,
+}
+
+/// Possible function available to processes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Extrinsic {
+    NextMessage,
+    EmitMessage,
+    EmitMessageError,
+    EmitAnswer,
+    CancelMessage,
+}
+
+/// Structure passed to the underlying [`processes::ProcessesCollection`] that tracks the state
+/// of the thread.
+struct LocalThreadUserData<TTud> {
+    /// State of a thread.
+    state: LocalThreadState,
+    /// User data decided by the user.
+    external_user_data: TTud,
+}
+
+/// State of a thread. Stored within the [`processes::ProcessesCollection`].
+enum LocalThreadState {
+    /// Thread is ready to run, running, or has just called an extrinsic and the call is being
+    /// processed.
+    ReadyToRun,
+
+    /// The thread is sleeping and waiting for a message to come.
+    MessageWait(MessageWait),
+
+    /// The thread called `emit_message` and wants to emit a message on an interface.
+    EmitMessage(EmitMessage),
+}
+
+/// Outcome of the [`run`](ProcessesCollectionExtrinsics::run) function.
+#[derive(Debug)]
+pub enum RunOneOutcome<'a, TPud, TTud> {
+    /// Either the main thread of a process has finished, or a fatal error was encountered.
+    ///
+    /// The process no longer exists.
+    ProcessFinished {
+        /// Pid of the process that has finished.
+        pid: Pid,
+
+        /// User data of the process.
+        user_data: TPud,
+
+        /// Id and user datas of all the threads of the process. The first element is the main
+        /// thread's.
+        /// These threads no longer exist.
+        dead_threads: Vec<(ThreadId, TTud)>,
+
+        /// Value returned by the main thread that has finished, or error that happened.
+        outcome: Result<Option<wasmi::RuntimeValue>, wasmi::Trap>,
+    },
+
+    /// A thread in a process has finished.
+    ThreadFinished {
+        /// Process whose thread has finished.
+        process: ProcessesCollectionExtrinsicsProc<'a, TPud, TTud>,
+
+        /// User data of the thread.
+        user_data: TTud,
+
+        /// Value returned by the function that was executed.
+        value: Option<wasmi::RuntimeValue>,
+    },
+
+    /// A thread in a process wants to emit a message.
+    ThreadEmitMessage(ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud>),
+
+    /// A thread in a process is waiting for an incoming message.
+    ThreadWaitMessage(ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud>),
+
+    /// A thread in a process wants to answer a message.
+    ThreadEmitAnswer {
+        /// Thread that wants to emit an answer.
+        thread: ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud>,
+
+        /// Message to answer.
+        message_id: MessageId,
+
+        /// The answer it self.
+        response: EncodedMessage,
+    },
+
+    /// A thread in a process wants to notify that a message is erroneous.
+    ThreadEmitMessageError {
+        /// Thread that wants to emit a message error.
+        thread: ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud>,
+
+        /// Message that is erroneous.
+        message_id: MessageId,
+    },
+
+    /// No thread is ready to run. Nothing was done.
+    Idle,
+}
+
+impl<TPud, TTud> ProcessesCollectionExtrinsics<TPud, TTud> {
+    /// Creates a new process state machine from the given module.
+    ///
+    /// The closure is called for each import that the module has. It must assign a number to each
+    /// import, or return an error if the import can't be resolved. When the VM calls one of these
+    /// functions, this number will be returned back in order for the user to know how to handle
+    /// the call.
+    ///
+    /// A single main thread (whose user data is passed by parameter) is automatically created and
+    /// is paused at the start of the "_start" function of the module.
+    pub fn execute(
+        &mut self,
+        module: &Module,
+        proc_user_data: TPud,
+        main_thread_user_data: TTud,
+    ) -> Result<ProcessesCollectionExtrinsicsProc<TPud, TTud>, vm::NewErr> {
+        self.inner.execute(module, proc_user_data, main_thread_user_data)
+    }
+
+    /// Runs one thread amongst the collection.
+    ///
+    /// Which thread is run is implementation-defined and no guarantee is made.
+    pub fn run(&mut self) -> RunOneOutcome<TPud, TTud> {
+        match self.inner.run() {
+            processes::RunOneOutcome::ProcessFinished { pid, user_data, dead_threads, outcome } => {
+                RunOneOutcome::ProcessFinished { pid, user_data, dead_threads, outcome }
+            },
+            processes::RunOneOutcome::ThreadFinished { process, user_data, value } => {
+                debug_assert_eq!(user_data.state, LocalThreadState::ReadyToRun);
+                RunOneOutcome::ThreadFinished { process, user_data: user_data.external_user_data, value }
+            },
+            processes::RunOneOutcome::Idle => RunOneOutcome::Idle,
+
+            processes::RunOneOutcome::Interrupted {
+                mut thread,
+                id: Extrinsic::NextMessage,
+                params,
+            } => {
+                debug_assert_eq!(*thread.user_data().state, LocalThreadState::ReadyToRun);
+                let next_msg = match parse_extrinsic_next_message(&mut thread, params) {
+                    Ok(m) => m,
+                    Err(_) => panic!(),     // TODO:
+                };
+                *thread.user_data().state = LocalThreadState::MessageWait(next_msg);
+                RunOneOutcome::ThreadWaitMessage(ProcessesCollectionExtrinsicsThreadWaitMessage {
+                    inner: thread,
+                })
+            }
+
+            processes::RunOneOutcome::Interrupted {
+                mut thread,
+                id: Extrinsic::EmitMessage,
+                params,
+            } => {
+                debug_assert_eq!(*thread.user_data().state, LocalThreadState::ReadyToRun);
+                let emit_msg = match parse_extrinsic_emit_message(&mut thread, params) {
+                    Ok(m) => m,
+                    Err(_) => panic!(),     // TODO:
+                };
+                *thread.user_data().state = LocalThreadState::EmitMessage(emit_msg);
+                RunOneOutcome::ThreadEmitMessage(ProcessesCollectionExtrinsicsThreadEmitMessage {
+                    inner: thread,
+                })
+            }
+
+            processes::RunOneOutcome::Interrupted {
+                mut thread,
+                id: Extrinsic::EmitAnswer,
+                params,
+            } => {
+                debug_assert_eq!(*thread.user_data().state, LocalThreadState::ReadyToRun);
+                let emit_resp = match parse_extrinsic_emit_answer(&mut thread, params) {
+                    Ok(m) => m,
+                    Err(_) => panic!(),     // TODO:
+                };
+                thread.resume(None);
+                RunOneOutcome::ThreadEmitAnswer {
+                    thread: ProcessesCollectionExtrinsicsThreadEmitMessage {
+                        inner: thread,
+                    },
+                    message_id: emit_resp.message_id,
+                    response: emit_resp.response,
+                }
+            }
+
+            processes::RunOneOutcome::Interrupted {
+                mut thread,
+                id: Extrinsic::EmitMessageError,
+                params,
+            } => {
+                debug_assert_eq!(*thread.user_data().state, LocalThreadState::ReadyToRun);
+                let emit_msg_error = match parse_extrinsic_emit_message_error(&mut thread, params) {
+                    Ok(m) => m,
+                    Err(_) => panic!(),     // TODO:
+                };
+                thread.resume(None);
+                RunOneOutcome::ThreadEmitMessageError {
+                    thread: ProcessesCollectionExtrinsicsThreadEmitMessage {
+                        inner: thread,
+                    },
+                    message_id: emit_msg_error,
+                }
+            }
+
+            processes::RunOneOutcome::Interrupted {
+                mut thread,
+                id: Extrinsic::CancelMessage,
+                params,
+            } => unimplemented!(),
+        }
+    }
+
+    /// Returns an iterator to all the processes that exist in the collection.
+    pub fn pids<'a>(&'a self) -> impl ExactSizeIterator<Item = Pid> + 'a {
+        self.processes.keys().cloned()
+    }
+
+    /// Returns a process by its [`Pid`], if it exists.
+    pub fn process_by_id(&mut self, pid: Pid) -> Option<ProcessesCollectionExtrinsicsProc<TPud, TTud>> {
+        let inner = self.inner.process_by_id(pid)?;
+        Some(ProcessesCollectionExtrinsicsProc {
+            inner,
+        })
+    }
+
+    /// Returns a thread by its [`ThreadId`], if it exists.
+    pub fn thread_by_id(&mut self, id: ThreadId) -> Option<ProcessesCollectionExtrinsicsThread<TPud, TTud>> {
+        let inner = self.inner.thread_by_id(id)?;
+        Some(ProcessesCollectionExtrinsicsThread::from_inner(inner))
+    }
+}
+
+impl Default for ProcessesCollectionExtrinsicsBuilder {
+    fn default() -> ProcessesCollectionExtrinsicsBuilder {
+        let mut inner = processes::ProcessesCollection::default()
+            .with_extrinsic(
+                "redshirt",
+                "next_message",
+                sig!((I32, I32, I32, I32, I32) -> I32),
+                Extrinsic::NextMessage,
+            )
+            .with_extrinsic(
+                "redshirt",
+                "emit_message",
+                sig!((I32, I32, I32, I32, I32, I32) -> I32),
+                Extrinsic::EmitMessage,
+            )
+            .with_extrinsic(
+                "redshirt",
+                "emit_message_error",
+                sig!((I32)),
+                Extrinsic::EmitMessageError,
+            )
+            .with_extrinsic(
+                "redshirt",
+                "emit_answer",
+                sig!((I32, I32, I32)),
+                Extrinsic::EmitAnswer,
+            )
+            .with_extrinsic(
+                "redshirt",
+                "cancel_message",
+                sig!((I32)),
+                Extrinsic::CancelMessage,
+            );
+
+        ProcessesCollectionExtrinsicsBuilder {
+            inner,
+        }
+    }
+}
+
+impl ProcessesCollectionExtrinsicsBuilder {
+    /// Allocates a `Pid` that will not be used by any process.
+    ///
+    /// > **Note**: As of the writing of this comment, this feature is only ever used to allocate
+    /// >           `Pid`s that last forever. There is therefore no corresponding "unreserve_pid"
+    /// >           method that frees such an allocated `Pid`. If there is ever a need to free
+    /// >           these `Pid`s, such a method should be added.
+    pub fn reserve_pid(&mut self) -> Pid {
+        // Note that we take `&mut self`. It could be `&self`, but that would expose
+        // implementation details.
+        self.pid_pool.assign()
+    }
+
+    /// Turns the builder into a [`ProcessesCollectionExtrinsics`].
+    pub fn build<TPud, TTud>(mut self) -> ProcessesCollectionExtrinsics<TPud, TTud> {
+        ProcessesCollectionExtrinsics {
+            inner: self.inner.build()
+        }
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsProc<'a, TPud, TTud> {
+    /// Returns the [`Pid`] of the process. Allows later retrieval by calling
+    /// [`process_by_id`](ProcessesCollection::process_by_id).
+    pub fn pid(&self) -> Pid {
+        self.inner.pid()
+    }
+
+    /// Returns the user data that is associated to the process.
+    pub fn user_data(&mut self) -> &mut TPud {
+        self.inner.user_data()
+    }
+
+    /// Adds a new thread to the process, starting the function with the given index and passing
+    /// the given parameters.
+    ///
+    /// > **Note**: The "function ID" is the index of the function in the WASM module. WASM
+    /// >           doesn't have function pointers. Instead, all the functions are part of a single
+    /// >           global array of functions.
+    // TODO: don't expose wasmi::RuntimeValue in the API
+    pub fn start_thread(
+        mut self,
+        fn_index: u32,
+        params: Vec<wasmi::RuntimeValue>,
+        user_data: TTud,
+    ) -> Result<ProcessesCollectionExtrinsicsThread<'a, TPud, TTud>, vm::StartErr> {
+        let thread = self.inner.start_thread(fn_index, params, LocalThreadUserData {
+            state: LocalThreadState::ReadyToRun,
+            external_user_data: user_data,
+        });
+
+        Ok(From::from(ProcessesCollectionExtrinsicsThreadRegular {
+            inner: thread,
+        }))
+    }
+
+    /// Returns an object representing the main thread of this process.
+    ///
+    /// The "main thread" of a process is created automatically when you call
+    /// [`ProcessesCollection::execute`]. If it stops, the entire process stops.
+    pub fn main_thread(self) -> ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+        ProcessesCollectionExtrinsicsThread::from_inner(self.inner.main_thread())
+    }
+
+    /// Aborts the process and returns the associated user data.
+    pub fn abort(self) -> (TPud, Vec<(ThreadId, TTud)>) {
+        //self.inner.abort()
+        unimplemented!()
+    }
+}
+
+impl<'a, TPud, TTud> fmt::Debug for ProcessesCollectionExtrinsicsProc<'a, TPud, TTud>
+where
+    TPud: fmt::Debug,
+    TTud: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // TODO: threads user data
+        f.debug_struct("ProcessesCollectionExtrinsicsProc")
+            .field("pid", &self.pid())
+            //.field("user_data", self.user_data())     // TODO: requires &mut self :-/
+            .finish()
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+    fn from_inner(inner: processes::ProcessesCollectionThread<'a, TPud, LocalThreadUserData<TTud>>) -> Self {
+        enum Ty {
+            Regular,
+            Emit,
+            Wait,
+        }
+
+        let ty = match inner.user_data().state {
+            LocalThreadState::ReadyToRun => Ty::Regular,
+            LocalThreadState::EmitMessage(_) => Ty::Emit,
+            LocalThreadState::WaitMessage(_) => Ty::Wait,
+        };
+
+        match ty {
+            Ty::Regular => From::from(ProcessesCollectionExtrinsicsThreadRegular {
+                inner,
+            }),
+            Ty::Emit => From::from(ProcessesCollectionExtrinsicsThreadEmitMessage {
+                inner,
+            }),
+            Ty::Wait => From::from(ProcessesCollectionExtrinsicsThreadWaitMessage {
+                inner,
+            }),
+        }
+    }
+}
+
+impl<'a, TPud, TTud> From<ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud>> for ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+    fn from(thread: ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud>) -> Self {
+        ProcessesCollectionExtrinsicsThread::Regular(thread)
+    }
+}
+
+impl<'a, TPud, TTud> From<ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud>> for ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+    fn from(thread: ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud>) -> Self {
+        ProcessesCollectionExtrinsicsThread::EmitMessage(thread)
+    }
+}
+
+impl<'a, TPud, TTud> From<ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud>> for ProcessesCollectionExtrinsicsThread<'a, TPud, TTud> {
+    fn from(thread: ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud>) -> Self {
+        ProcessesCollectionExtrinsicsThread::WaitMessage(thread)
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsThreadAccess for ProcessesCollectionExtrinsicsThreadRegular<'a, TPud, TTud> {
+    type ProcessUserData = TPud;
+    type ThreadUserData = TTud;
+
+    fn tid(&mut self) -> ThreadId {
+        self.inner.tid()
+    }
+
+    fn pid(&self) -> Pid {
+        self.inner.pid()
+    }
+
+    fn process_user_data(&mut self) -> &mut TPud {
+        self.inner.process_user_data()
+    }
+
+    fn user_data(&mut self) -> &mut TTud {
+        &mut self.inner.user_data().user_data
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsThreadAccess for ProcessesCollectionExtrinsicsThreadEmitMessage<'a, TPud, TTud> {
+    type ProcessUserData = TPud;
+    type ThreadUserData = TTud;
+
+    fn tid(&mut self) -> ThreadId {
+        self.inner.tid()
+    }
+
+    fn pid(&self) -> Pid {
+        self.inner.pid()
+    }
+
+    fn process_user_data(&mut self) -> &mut TPud {
+        self.inner.process_user_data()
+    }
+
+    fn user_data(&mut self) -> &mut TTud {
+        &mut self.inner.user_data().user_data
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud> {
+    /// Returns the list of message IDs that the thread is waiting on. In order.
+    pub fn message_ids_iter(&self) -> impl Iterator<Item = MessageId> {
+        if let LocalThreadState::WaitMessage(ref wait) = self.inner.user_data().state {
+            wait.message_ids.iter().cloned()
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Returns the maximum size allowed for a message.
+    pub fn allow_message_size(&self) -> u32 {
+        if let LocalThreadState::WaitMessage(ref wait) = self.inner.user_data().state {
+            wait.out_size
+        } else {
+            unreachable!()
+        }
+    }
+
+    /// Resume the thread, indicating that the message is too large for the provided buffer.
+    pub fn resume_message_too_big(self, message_size: u32) {
+        self.inner.user_data().state = LocalThreadState::ReadyToRun;
+        // TODO: do some reinterpret_cast-like stuff instead of i32::try_from
+        self.inner.resume(Some(wasmi::RuntimeValue::I32(i32::try_from(message_size).unwrap())));
+    }
+
+    /// Resume the thread, indicating that no message is available.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `block` was set to `true`.
+    pub fn resume_no_message(self, message_size: u32) {
+        self.inner.user_data().state = LocalThreadState::ReadyToRun;
+        self.inner.resume(Some(wasmi::RuntimeValue::I32(i32::try_from(message_size).unwrap())));
+    }
+}
+
+impl<'a, TPud, TTud> ProcessesCollectionExtrinsicsThreadAccess for ProcessesCollectionExtrinsicsThreadWaitMessage<'a, TPud, TTud> {
+    type ProcessUserData = TPud;
+    type ThreadUserData = TTud;
+
+    fn tid(&mut self) -> ThreadId {
+        self.inner.tid()
+    }
+
+    fn pid(&self) -> Pid {
+        self.inner.pid()
+    }
+
+    fn process_user_data(&mut self) -> &mut TPud {
+        self.inner.process_user_data()
+    }
+
+    fn user_data(&mut self) -> &mut TTud {
+        &mut self.inner.user_data().user_data
+    }
+}
+
+// TODO:
+/*impl<'a, TPud, TTud> fmt::Debug for ProcessesCollectionExtrinsicsThread<'a, TPud, TTud>
+where
+    TPud: fmt::Debug,
+    TTud: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        //let id = self.id();
+        let pid = self.pid();
+        // TODO: requires &mut self :-/
+        //let ready_to_run = self.inner().into_user_data().value_back.is_some();
+
+        f.debug_struct("ProcessesCollectionExtrinsicsThread")
+            .field("pid", &pid)
+            //.field("thread_id", &id)
+            //.field("user_data", self.user_data())
+            //.field("ready_to_run", &ready_to_run)
+            .finish()
+    }
+}*/
+
+/// Analyzes a call to `next_message` made by the given thread.
+///
+/// The `thread` parameter is only used in order to read memory from the process. This function
+/// has no side effect.
+///
+/// Returns an error if the call is invalid.
+fn parse_extrinsic_next_message<TPud, TTud>(
+    thread: &mut processes::ProcessesCollectionThread<TPud, LocalThreadUserData<TTud>>,
+    params: Vec<wasmi::RuntimeValue>,
+) -> Result<MessageWait, ()> {
+    // We use an assert here rather than a runtime check because the WASM VM (rather than us) is
+    // supposed to check the function signature.
+    assert_eq!(params.len(), 5);
+
+    let msg_ids_ptr = u32::try_from(params[0].try_into::<i32>().ok_or(())?).ok_or(())?;
+    // TODO: consider not copying the message ids and read memory on demand instead
+    let msg_ids = {
+        let len = u32::try_from(params[1].try_into::<i32>().ok_or(())?).ok_or(())?;
+        if len >= 512 {
+            // TODO: arbitrary limit in order to not allocate too much memory below; a bit crappy
+            return Err(())
+        }
+        let mem = thread.read_memory(msg_ids_ptr, len * 8)?;
+        let mut out = vec![MessageId::from(0u64); usize::try_from(len).ok_or(())?];
+        for (o, i) in out.iter_mut().zip(mem.chunks(8)) {
+            let val = byteorder::LittleEndian::read_u64(i);
+            *o = MessageId::from(val);
+        }
+        out
+    };
+
+    let out_pointer = u32::try_from(params[2].try_into::<i32>().ok_or(())?).ok_or(())?;
+    let out_size = u32::try_from(params[3].try_into::<i32>().ok_or(())?).ok_or(())?;
+    let block = params[4].try_into::<i32>().ok_or(())? != 0;
+
+    Ok(MessageWait {
+        msg_ids,
+        msg_ids_ptr,
+        out_pointer,
+        out_size,
+    })
+}
+
+/// Analyzes a call to `emit_message` made by the given thread.
+///
+/// The `thread` parameter is only used in order to read memory from the process. This function
+/// has no side effect.
+///
+/// Returns an error if the call is invalid.
+fn parse_extrinsic_emit_message<TPud, TTud>(
+    thread: &mut processes::ProcessesCollectionThread<TPud, LocalThreadUserData<TTud>>,
+    params: Vec<wasmi::RuntimeValue>,
+) -> Result<EmitMessage, ()> {
+    // We use an assert here rather than a runtime check because the WASM VM (rather than us) is
+    // supposed to check the function signature.
+    assert_eq!(params.len(), 6);
+
+    let interface: InterfaceHash = {
+        let addr = u32::try_from(params[0].try_into::<i32>().ok_or(())?).ok_or(())?;
+        InterfaceHash::from(
+            <[u8; 32]>::try_from(&thread.read_memory(addr, 32)?[..])?,
+        )
+    };
+
+    let message = {
+        let addr = u32::try_from(params[1].try_into::<i32>().ok_or(())?).ok_or(())?;
+        let num_bufs = u32::try_from(params[2].try_into::<i32>().ok_or(())?).ok_or(())?;
+        let mut out_msg = Vec::new();
+        for buf_n in 0..num_bufs {
+            let sub_buf_ptr = thread.read_memory(addr + 8 * buf_n, 4).ok_or(())?;
+            let sub_buf_ptr = LittleEndian::read_u32(&sub_buf_ptr);
+            let sub_buf_sz = thread.read_memory(addr + 8 * buf_n + 4, 4).ok_or(())?;
+            let sub_buf_sz = LittleEndian::read_u32(&sub_buf_sz);
+            if out_msg.len() + usize::try_from(sub_buf_sz).ok_or(())? >= 16 * 1024 * 1024 {
+                // TODO: arbitrary maximum message length
+                panic!("Max message length reached");
+                //return Err(());
+            }
+            out_msg.extend_from_slice(
+                &thread.read_memory(sub_buf_ptr, sub_buf_sz).ok_or(())?,
+            );
+        }
+        EncodedMessage(out_msg)
+    };
+
+    let needs_answer = params[3].try_into::<i32>().ok_or(())? != 0;
+    let allow_delay = params[4].try_into::<i32>().ok_or(())? != 0;
+    let message_id_write = if needs_answer {
+        Some(u32::try_from(params[5].try_into::<i32>().ok_or(())?).ok_or(())?)
+    } else {
+        None
+    };
+
+    Ok(EmitMessage {
+        interface,
+        message_id_write,
+        message,
+        allow_delay,
+    })
+}
+
+/// Analyzes a call to `emit_answer` made by the given thread.
+///
+/// The `thread` parameter is only used in order to read memory from the process. This function
+/// has no side effect.
+///
+/// Returns an error if the call is invalid.
+fn parse_extrinsic_emit_answer<TPud, TTud>(
+    thread: &mut processes::ProcessesCollectionThread<TPud, LocalThreadUserData<TTud>>,
+    params: Vec<wasmi::RuntimeValue>,
+) -> Result<EmitAnswer, ()> {
+    // We use an assert here rather than a runtime check because the WASM VM (rather than us) is
+    // supposed to check the function signature.
+    assert_eq!(params.len(), 3);
+
+    let message_id = {
+        let addr = u32::try_from(params[0].try_into::<i32>().ok_or(())?).ok_or(())?;
+        let buf = thread.read_memory(addr, 8)?;
+        MessageId::from(byteorder::LittleEndian::read_u64(&buf))
+    };
+
+    let response = {
+        let addr = u32::try_from(params[1].try_into::<i32>().ok_or(())?).ok_or(())?;
+        let sz = u32::try_from(params[2].try_into::<i32>().ok_or(())?).ok_or(())?;
+        EncodedMessage(thread.read_memory(addr, sz)?)
+    };
+    
+    Ok(EmitAnswer {
+        message_id,
+        response,
+    })
+}
+
+/// Analyzes a call to `emit_message_error` made by the given thread.
+/// Returns the message for which to notify of an error.
+///
+/// The `thread` parameter is only used in order to read memory from the process. This function
+/// has no side effect.
+///
+/// Returns an error if the call is invalid.
+fn parse_extrinsic_emit_message_error<TPud, TTud>(
+    thread: &mut processes::ProcessesCollectionThread<TPud, LocalThreadUserData<TTud>>,
+    params: Vec<wasmi::RuntimeValue>,
+) -> Result<u64, ()> {
+    // We use an assert here rather than a runtime check because the WASM VM (rather than us) is
+    // supposed to check the function signature.
+    assert_eq!(params.len(), 1);
+
+    let msg_id = {
+        let addr = u32::try_from(params[0].try_into::<i32>().ok_or(())?).ok_or(())?;
+        let buf = thread.read_memory(addr, 8)?;
+        MessageId::from(byteorder::LittleEndian::read_u64(&buf))
+    };
+
+    Ok(msg_id)
+}

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -15,7 +15,7 @@
 
 use crate::id_pool::IdPool;
 use crate::module::Module;
-use crate::scheduler::{processes, vm};
+use crate::scheduler::{extrinsics::{self, ProcessesCollectionExtrinsicsExtrinsicsThreadAccess as _}, vm};
 use crate::sig;
 use crate::signature::Signature;
 use crate::InterfaceHash;
@@ -34,7 +34,7 @@ pub struct Core {
     pending_events: SegQueue<CoreRunOutcomeInner>,
 
     /// List of running processes.
-    processes: processes::ProcessesCollection<Extrinsic, Process, Thread>,
+    processes: extrinsics::ProcessesCollectionExtrinsics<Process, ()>,
 
     /// List of `Pid`s that have been reserved during the construction.
     ///
@@ -68,22 +68,12 @@ enum InterfaceState {
     },
 }
 
-/// Possible function available to processes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum Extrinsic {
-    NextMessage,
-    EmitMessage,
-    EmitMessageError,
-    EmitAnswer,
-    CancelMessage,
-}
-
 /// Prototype for a `Core` under construction.
 pub struct CoreBuilder {
     /// See the corresponding field in `Core`.
     reserved_pids: HashSet<Pid>,
     /// Builder for the [`processes`][Core::processes] field in `Core`.
-    inner_builder: processes::ProcessesCollectionBuilder<Extrinsic>,
+    inner_builder: extrinsics::ProcessesCollectionExtrinsicsBuilder,
 }
 
 /// Outcome of calling [`run`](Core::run).
@@ -196,36 +186,6 @@ struct Process {
     messages_to_answer: SmallVec<[MessageId; 8]>,
 }
 
-/// Additional information about a thread. Must be consistent with the actual state of the thread.
-#[derive(Debug, PartialEq, Eq)]
-enum Thread {
-    /// Thread is ready to run.
-    ReadyToRun,
-
-    /// The thread is sleeping and waiting for a message to come.
-    ///
-    /// Note that this can be set even if the `messages_queue` is not empty, in the case where
-    /// the thread is waiting only on messages that aren't in the queue.
-    MessageWait(MessageWait),
-
-    /// The thread called `emit_message` and wants to emit a message on an interface for which no
-    /// handler was available at the time.
-    InterfaceNotAvailableWait {
-        /// Interface we want to emit the message on.
-        interface: InterfaceHash,
-        /// Identifier of the message if it expects an answer.
-        message_id: Option<MessageId>,
-        /// Message itself. Needs to be delivered to the handler once it is registered.
-        message: EncodedMessage,
-    },
-
-    /// The thread is sleeping and waiting for an external extrinsic.
-    ExtrinsicWait,
-
-    /// Thread has been interrupted, and the call is being processed right now.
-    InProcess,
-}
-
 /// How a process is waiting for messages.
 #[derive(Debug, Clone, PartialEq, Eq)] // TODO: remove Clone
 struct MessageWait {
@@ -244,52 +204,21 @@ struct MessageWait {
 /// Access to a process within the core.
 pub struct CoreProcess<'a> {
     /// Access to the process within the inner collection.
-    process: processes::ProcessesCollectionProc<'a, Process, Thread>,
+    process: extrinsics::ProcessesCollectionExtrinsicsProc<'a, Process, ()>,
 }
 
 /// Access to a thread within the core.
 pub struct CoreThread<'a> {
     /// Access to the thread within the inner collection.
-    thread: processes::ProcessesCollectionThread<'a, Process, Thread>,
+    thread: extrinsics::ProcessesCollectionExtrinsicsThread<'a, Process, ()>,
 }
 
 impl Core {
-    // TODO: figure out borrowing issues and remove that Clone
     /// Initialies a new `Core`.
     pub fn new() -> CoreBuilder {
         CoreBuilder {
             reserved_pids: HashSet::new(),
-            inner_builder: processes::ProcessesCollectionBuilder::default()
-                .with_extrinsic(
-                    "redshirt",
-                    "next_message",
-                    sig!((I32, I32, I32, I32, I32) -> I32),
-                    Extrinsic::NextMessage,
-                )
-                .with_extrinsic(
-                    "redshirt",
-                    "emit_message",
-                    sig!((I32, I32, I32, I32, I32, I32) -> I32),
-                    Extrinsic::EmitMessage,
-                )
-                .with_extrinsic(
-                    "redshirt",
-                    "emit_message_error",
-                    sig!((I32)),
-                    Extrinsic::EmitMessageError,
-                )
-                .with_extrinsic(
-                    "redshirt",
-                    "emit_answer",
-                    sig!((I32, I32, I32)),
-                    Extrinsic::EmitAnswer,
-                )
-                .with_extrinsic(
-                    "redshirt",
-                    "cancel_message",
-                    sig!((I32)),
-                    Extrinsic::CancelMessage,
-                ),
+            inner_builder: extrinsics::ProcessesCollectionExtrinsicsExtrinsicsBuilder::default()
         }
     }
 
@@ -355,7 +284,7 @@ impl Core {
         }
 
         match self.processes.run() {
-            processes::RunOneOutcome::ProcessFinished {
+            extrinsics::RunOneOutcome::ProcessFinished {
                 pid,
                 outcome,
                 dead_threads,
@@ -419,58 +348,31 @@ impl Core {
                 }
             }
 
-            processes::RunOneOutcome::ThreadFinished { user_data, .. } => {
+            extrinsics::RunOneOutcome::ThreadFinished { user_data, .. } => {
                 debug_assert_eq!(user_data, Thread::ReadyToRun);
                 // TODO: report?
                 CoreRunOutcomeInner::LoopAgain
             }
 
-            processes::RunOneOutcome::Interrupted {
-                mut thread,
-                id: Extrinsic::NextMessage,
-                params,
-            } => {
-                debug_assert_eq!(*thread.user_data(), Thread::ReadyToRun);
-                *thread.user_data() = Thread::InProcess;
-                // TODO: refactor a bit to first parse the parameters and then update `self`
-                extrinsic_next_message(&mut thread, params);
+            extrinsics::RunOneOutcome::ThreadWaitMessage(thread) {
+                /*
+                try_resume_message_wait_thread(thread);
+
+                // If `block` is false, we put the thread to sleep anyway, then wake it up again here.
+                if !block && *thread.user_data() != Thread::ReadyToRun {
+                    debug_assert!(if let Thread::MessageWait(_) = thread.user_data() {
+                        true
+                    } else {
+                        false
+                    });
+                    *thread.user_data() = Thread::ReadyToRun;
+                    thread.resume(Some(wasmi::RuntimeValue::I32(0)));
+                }
+                */
                 CoreRunOutcomeInner::LoopAgain
             }
 
-            processes::RunOneOutcome::Interrupted {
-                mut thread,
-                id: Extrinsic::EmitMessage,
-                params,
-            } => {
-                debug_assert_eq!(*thread.user_data(), Thread::ReadyToRun);
-                *thread.user_data() = Thread::InProcess;
-
-                // TODO: lots of unwraps here
-                assert_eq!(params.len(), 6);
-                let interface: InterfaceHash = {
-                    let addr = params[0].try_into::<i32>().unwrap() as u32;
-                    InterfaceHash::from(
-                        <[u8; 32]>::try_from(&thread.read_memory(addr, 32).unwrap()[..]).unwrap(),
-                    )
-                };
-                let message = {
-                    let addr = params[1].try_into::<i32>().unwrap() as u32;
-                    let num_bufs = params[2].try_into::<i32>().unwrap() as u32;
-                    let mut out_msg = Vec::new();
-                    for buf_n in 0..num_bufs {
-                        let sub_buf_ptr = thread.read_memory(addr + 8 * buf_n, 4).unwrap();
-                        let sub_buf_ptr = LittleEndian::read_u32(&sub_buf_ptr);
-                        let sub_buf_sz = thread.read_memory(addr + 8 * buf_n + 4, 4).unwrap();
-                        let sub_buf_sz = LittleEndian::read_u32(&sub_buf_sz);
-                        out_msg.extend_from_slice(
-                            &thread.read_memory(sub_buf_ptr, sub_buf_sz).unwrap(),
-                        );
-                    }
-                    EncodedMessage(out_msg)
-                };
-                let needs_answer = params[3].try_into::<i32>().unwrap() != 0;
-                let allow_delay = params[4].try_into::<i32>().unwrap() != 0;
-                let emitter_pid = thread.pid();
+            extrinsics::RunOneOutcome::ThreadEmitMessage(thread) {
                 let message_id = if needs_answer {
                     let message_id_write = params[5].try_into::<i32>().unwrap() as u32;
                     let new_message_id = loop {
@@ -569,63 +471,19 @@ impl Core {
                 }
             }
 
-            processes::RunOneOutcome::Interrupted {
-                mut thread,
-                id: Extrinsic::EmitAnswer,
-                params,
-            } => {
-                debug_assert_eq!(*thread.user_data(), Thread::ReadyToRun);
-                *thread.user_data() = Thread::InProcess;
-
-                // TODO: lots of unwraps here
-                assert_eq!(params.len(), 3);
-                let msg_id = {
-                    let addr = params[0].try_into::<i32>().unwrap() as u32;
-                    let buf = thread.read_memory(addr, 8).unwrap();
-                    MessageId::from(byteorder::LittleEndian::read_u64(&buf))
-                };
-                let message = {
-                    let addr = params[1].try_into::<i32>().unwrap() as u32;
-                    let sz = params[2].try_into::<i32>().unwrap() as u32;
-                    EncodedMessage(thread.read_memory(addr, sz).unwrap())
-                };
-                let pid = thread.pid();
-                thread.resume(None);
-                self.answer_message_inner(msg_id, Ok(message))
+            extrinsics::RunOneOutcome::ThreadEmitAnswer { message_id, response, .. } => {
+                // TODO: check ownership of the message
+                self.answer_message_inner(message_id, Ok(response))
                     .unwrap_or(CoreRunOutcomeInner::LoopAgain)
             }
 
-            processes::RunOneOutcome::Interrupted {
-                mut thread,
-                id: Extrinsic::EmitMessageError,
-                params,
-            } => {
-                debug_assert_eq!(*thread.user_data(), Thread::ReadyToRun);
-                *thread.user_data() = Thread::InProcess;
-
-                // TODO: lots of unwraps here
-                assert_eq!(params.len(), 1);
-                let msg_id = {
-                    let addr = params[0].try_into::<i32>().unwrap() as u32;
-                    let buf = thread.read_memory(addr, 8).unwrap();
-                    MessageId::from(byteorder::LittleEndian::read_u64(&buf))
-                };
-
-                self.messages_to_answer.remove(&msg_id);
-                thread.resume(None);
-
-                let pid = thread.pid();
+            extrinsics::RunOneOutcome::ThreadEmitMessageError { message_id, .. } => {
+                // TODO: check ownership of the message
                 self.answer_message_inner(msg_id, Err(()))
                     .unwrap_or(CoreRunOutcomeInner::LoopAgain)
             }
 
-            processes::RunOneOutcome::Interrupted {
-                mut thread,
-                id: Extrinsic::CancelMessage,
-                params,
-            } => unimplemented!(),
-
-            processes::RunOneOutcome::Idle => CoreRunOutcomeInner::Idle,
+            extrinsics::RunOneOutcome::Idle => CoreRunOutcomeInner::Idle,
         }
     }
 
@@ -978,59 +836,9 @@ impl CoreBuilder {
     }
 }
 
-/// Called when a thread calls the `next_message` extrinsic.
-///
-/// Tries to resume the thread by fetching a message from the queue.
-///
-/// Returns an error if the extrinsic call was invalid.
-fn extrinsic_next_message(
-    thread: &mut processes::ProcessesCollectionThread<Process, Thread>,
-    params: Vec<wasmi::RuntimeValue>,
-) -> Result<(), ()> {
-    // TODO: lots of conversions here
-    assert_eq!(params.len(), 5);
-
-    let msg_ids_ptr = params[0].try_into::<i32>().ok_or(())? as u32;
-    let msg_ids = {
-        let addr = msg_ids_ptr;
-        let len = params[1].try_into::<i32>().ok_or(())? as u32;
-        let mem = thread.read_memory(addr, len * 8)?;
-        let mut out = vec![0u64; len as usize];
-        byteorder::LittleEndian::read_u64_into(&mem, &mut out);
-        out.into_iter().map(MessageId::from).collect::<Vec<_>>() // TODO: meh
-    };
-
-    let out_pointer = params[2].try_into::<i32>().ok_or(())? as u32;
-    let out_size = params[3].try_into::<i32>().ok_or(())? as u32;
-    let block = params[4].try_into::<i32>().ok_or(())? != 0;
-
-    assert!(*thread.user_data() == Thread::InProcess);
-    *thread.user_data() = Thread::MessageWait(MessageWait {
-        msg_ids,
-        msg_ids_ptr,
-        out_pointer,
-        out_size,
-    });
-
-    try_resume_message_wait_thread(thread);
-
-    // If `block` is false, we put the thread to sleep anyway, then wake it up again here.
-    if !block && *thread.user_data() != Thread::ReadyToRun {
-        debug_assert!(if let Thread::MessageWait(_) = thread.user_data() {
-            true
-        } else {
-            false
-        });
-        *thread.user_data() = Thread::ReadyToRun;
-        thread.resume(Some(wasmi::RuntimeValue::I32(0)));
-    }
-
-    Ok(())
-}
-
 /// If any of the threads of the given process is waiting for a message to arrive, checks the
 /// queue and tries to resume said thread.
-fn try_resume_message_wait(process: processes::ProcessesCollectionProc<Process, Thread>) {
+fn try_resume_message_wait(process: extrinsics::ProcessesCollectionExtrinsicsProc<Process, ()>) {
     // TODO: is it a good strategy to just go through threads in linear order? what about
     //       round-robin-ness instead?
     let mut thread = process.main_thread();
@@ -1049,16 +857,11 @@ fn try_resume_message_wait(process: processes::ProcessesCollectionProc<Process, 
 // TODO: in order to call this function, we essentially have to put the state machine in a "bad"
 // state (message in queue and thread would accept said message); not great
 fn try_resume_message_wait_thread(
-    thread: &mut processes::ProcessesCollectionThread<Process, Thread>,
+    thread: &mut extrinsics::ProcessesCollectionExtrinsicsThreadWaitMessage<Process, ()>,
 ) {
     if thread.process_user_data().messages_queue.is_empty() {
         return;
     }
-
-    let msg_wait = match thread.user_data() {
-        Thread::MessageWait(ref wait) => wait.clone(), // TODO: don't clone?
-        _ => return,
-    };
 
     // Try to find a message in the queue that matches something the user is waiting for.
     let mut index_in_queue = 0;
@@ -1078,7 +881,7 @@ fn try_resume_message_wait_thread(
             }
         };
 
-        if let Some(p) = msg_wait.msg_ids.iter().position(|id| *id == msg_id.into()) {
+        if let Some(p) = thread.message_ids_iter().position(|id| *id == msg_id.into()) {
             break p as u32;
         }
 

--- a/core/src/scheduler/ipc.rs
+++ b/core/src/scheduler/ipc.rs
@@ -407,7 +407,7 @@ impl Core {
                         *thread.user_data() = Thread::ReadyToRun;
                         thread.resume(Some(wasmi::RuntimeValue::I32(0)));
 
-                        if let Some(mut process) = self.processes.process_by_id(*pid) {
+                        if let Some(mut process) = self.processes.process_by_id(pid) {
                             let message = redshirt_syscalls_interface::ffi::Message::Interface(
                                 redshirt_syscalls_interface::ffi::InterfaceMessage {
                                     interface: interface.into(),
@@ -418,7 +418,7 @@ impl Core {
                                 },
                             );
 
-                            let mut process = match self.processes.process_by_id(*pid) {
+                            let mut process = match self.processes.process_by_id(pid) {
                                 Some(p) => p,
                                 None => unreachable!(),
                             };
@@ -845,7 +845,9 @@ fn try_resume_message_wait(process: extrinsics::ProcessesCollectionExtrinsicsPro
     let mut thread = process.main_thread();
 
     loop {
-        try_resume_message_wait_thread(&mut thread);
+        if let extrinsics::ProcessesCollectionExtrinsicsThread::WaitMessage(t) = &mut thread {
+            try_resume_message_wait_thread(t);
+        }
         match thread.next_thread() {
             Some(t) => thread = t,
             None => break,


### PR DESCRIPTION
There is now a new layer between `processes.rs` and `ipc.rs` called `extrinsics.rs`. It translates syscalls made by the WASM modules into strongly-typed events.
In the future, if a syscall is bad, it will also purposefully crash the process. This is something that would be way to difficult to handle with the current code structure.

This makes the code way cleaner and understandable, and opens the door for #165 .
