### PR TITLE
Remove the overhead of logging as much as possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,6 @@ name = "redshirt-log-interface"
 version = "0.1.0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-syscalls-interface 0.1.0",
 ]
 

--- a/interfaces/log/Cargo.toml
+++ b/interfaces/log/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2018"
 [dependencies]
 log = "0.4.8"
 redshirt-syscalls-interface = { path = "../syscalls", default-features = false }
-parity-scale-codec = { version = "1.0.5", default-features = false, features = ["derive", "full"] }

--- a/interfaces/log/src/ffi.rs
+++ b/interfaces/log/src/ffi.rs
@@ -26,7 +26,6 @@
 /// - Debug: 1
 /// - Trace: 0
 ///
-
 use core::{convert::TryFrom, str};
 use redshirt_syscalls_interface::{Decode, EncodedMessage, InterfaceHash};
 
@@ -68,7 +67,7 @@ impl TryFrom<u8> for Level {
             2 => Level::Info,
             1 => Level::Debug,
             0 => Level::Trace,
-            _ => return Err(())
+            _ => return Err(()),
         })
     }
 }
@@ -78,14 +77,11 @@ impl Decode for DecodedLogMessage {
 
     fn decode(buffer: EncodedMessage) -> Result<Self, ()> {
         if buffer.0.is_empty() {
-            return Err(())
+            return Err(());
         }
         let level = Level::try_from(buffer.0[0])?;
         let _ = str::from_utf8(&buffer.0[1..]).map_err(|_| ())?;
-        Ok(DecodedLogMessage {
-            level,
-            buffer,
-        })
+        Ok(DecodedLogMessage { level, buffer })
     }
 }
 

--- a/interfaces/syscalls/src/emit.rs
+++ b/interfaces/syscalls/src/emit.rs
@@ -74,12 +74,24 @@ where
         TLen: core::ops::Add<U8, Output = TOutLen>,
         TOutLen: ArrayLength<u8>,
     {
+        self.add_data_raw(&buffer.0)
+    }
+
+    /// Append a slice of message data to the builder.
+    ///
+    /// > **Note**: This operation is cheap and doesn't perform any copy of the message data
+    /// >           itself.
+    pub fn add_data_raw<TOutLen>(self, buffer: &'a [u8]) -> MessageBuilder<'a, TOutLen>
+    where
+        TLen: core::ops::Add<U8, Output = TOutLen>,
+        TOutLen: ArrayLength<u8>,
+    {
         let mut new_pair = GenericArray::<u8, U8>::default();
         LittleEndian::write_u32(
             &mut new_pair[0..4],
-            u32::try_from(buffer.0.as_ptr() as usize).unwrap(),
+            u32::try_from(buffer.as_ptr() as usize).unwrap(),
         );
-        LittleEndian::write_u32(&mut new_pair[4..8], u32::try_from(buffer.0.len()).unwrap());
+        LittleEndian::write_u32(&mut new_pair[4..8], u32::try_from(buffer.len()).unwrap());
 
         MessageBuilder {
             allow_delay: self.allow_delay,

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -25,8 +25,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "arm-log"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-hardware-interface 0.1.0",
  "redshirt-interface-interface 0.1.0",
  "redshirt-log-interface 0.1.0",
@@ -1358,7 +1356,6 @@ name = "redshirt-log-interface"
 version = "0.1.0"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-syscalls-interface 0.1.0",
 ]
 
@@ -2039,7 +2036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "x86-log"
 version = "0.1.0"
 dependencies = [
- "parity-scale-codec 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redshirt-hardware-interface 0.1.0",
  "redshirt-interface-interface 0.1.0",
  "redshirt-log-interface 0.1.0",

--- a/modules/arm-log/Cargo.toml
+++ b/modules/arm-log/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-byteorder = "1.3.2"
 redshirt-hardware-interface = { path = "../../interfaces/hardware" }
 redshirt-interface-interface = { path = "../../interfaces/interface" }
 redshirt-log-interface = { path = "../../interfaces/log" }
 redshirt-syscalls-interface = { path = "../../interfaces/syscalls" }
-parity-scale-codec = { version = "1.0.5", default-features = false }

--- a/modules/arm-log/src/main.rs
+++ b/modules/arm-log/src/main.rs
@@ -15,8 +15,7 @@
 
 //! Implements the log interface by writing in text mode.
 
-use byteorder::{ByteOrder as _, LittleEndian};
-use parity_scale_codec::DecodeAll;
+use redshirt_syscalls_interface::{Decode, EncodedMessage};
 use std::{convert::TryFrom as _, fmt};
 
 fn main() {
@@ -35,9 +34,9 @@ async fn async_main() -> ! {
         };
         assert_eq!(msg.interface, redshirt_log_interface::ffi::INTERFACE);
 
-        let redshirt_log_interface::ffi::LogMessage::Message(_, message) =
-            DecodeAll::decode_all(&msg.actual_data).unwrap();       // TODO: don't unwrap
-        for byte in message.as_bytes() {
+        let message: redshirt_log_interface::ffi::DecodedLogMessage =
+            Decode::decode(EncodedMessage(msg.actual_data)).unwrap();       // TODO: don't unwrap
+        for byte in message.message().as_bytes() {
             write_uart(*byte).await;
         }
         write_uart(b'\n').await;

--- a/modules/hello-world/src/main.rs
+++ b/modules/hello-world/src/main.rs
@@ -16,6 +16,6 @@
 fn main() {
     redshirt_log_interface::log(
         redshirt_log_interface::Level::Info,
-        "hello world!".to_string(),
+        &"hello world!",
     )
 }

--- a/modules/ne2000/src/device.rs
+++ b/modules/ne2000/src/device.rs
@@ -112,7 +112,7 @@ impl Device {
         // TODO: remove
         redshirt_log_interface::log(
             redshirt_log_interface::Level::Info,
-            format!("MAC: {:x} {:x} {:x} {:x} {:x} {:x}", mac_address[0], mac_address[1], mac_address[2], mac_address[3], mac_address[4], mac_address[5])
+            &format!("MAC: {:x} {:x} {:x} {:x} {:x} {:x}", mac_address[0], mac_address[1], mac_address[2], mac_address[3], mac_address[4], mac_address[5])
         );
 
         // Start page address of the packet to be transmitted.

--- a/modules/ne2000/src/main.rs
+++ b/modules/ne2000/src/main.rs
@@ -52,7 +52,7 @@ async fn async_main() {
                     ne2k_devices.push(device::Device::reset(port_number).await);
                     redshirt_log_interface::log(
                         redshirt_log_interface::Level::Info,
-                        format!("Initialized ne2000 at 0x{:x}", port_number)
+                        &format!("Initialized ne2000 at 0x{:x}", port_number)
                     );
                 }
             }
@@ -66,7 +66,7 @@ async fn async_main() {
     ne2k_devices.shrink_to_fit();
 
     loop {
-        //redshirt_log_interface::log(redshirt_log_interface::Level::Info, format!("Polling"));
+        //redshirt_log_interface::log(redshirt_log_interface::Level::Info, "Polling");
         let packet = match unsafe { ne2k_devices[0].read_one_incoming().await } {
             Some(p) => p,
             None => continue,
@@ -79,11 +79,11 @@ async fn async_main() {
                 let (udp_header, udp_data) = etherparse::UdpHeader::read_from_slice(&ip_data).unwrap();
                 redshirt_log_interface::log(
                     redshirt_log_interface::Level::Info,
-                    format!("Headers: {:?} {:?}", ip_header, udp_header)
+                    &format!("Headers: {:?} {:?}", ip_header, udp_header)
                 );
             }
         }
 
-        //redshirt_log_interface::log(redshirt_log_interface::Level::Info, format!("Header: {:?}", header));
+        //redshirt_log_interface::log(redshirt_log_interface::Level::Info, &format!("Header: {:?}", header));
     }
 }

--- a/modules/x86-log/Cargo.toml
+++ b/modules/x86-log/Cargo.toml
@@ -11,4 +11,3 @@ redshirt-hardware-interface = { path = "../../interfaces/hardware", default-feat
 redshirt-interface-interface = { path = "../../interfaces/interface" }
 redshirt-log-interface = { path = "../../interfaces/log" }
 redshirt-syscalls-interface = { path = "../../interfaces/syscalls" }
-parity-scale-codec = { version = "1.0.5", default-features = false }

--- a/modules/x86-log/src/main.rs
+++ b/modules/x86-log/src/main.rs
@@ -15,7 +15,7 @@
 
 //! Implements the log interface by writing in text mode.
 
-use parity_scale_codec::DecodeAll;
+use redshirt_syscalls_interface::{Decode, EncodedMessage};
 use std::{convert::TryFrom as _, fmt};
 
 fn main() {
@@ -36,9 +36,9 @@ async fn async_main() -> ! {
             redshirt_syscalls_interface::InterfaceOrDestroyed::ProcessDestroyed(_) => continue,
         };
         assert_eq!(msg.interface, redshirt_log_interface::ffi::INTERFACE);
-        let redshirt_log_interface::ffi::LogMessage::Message(_, message) =
-            DecodeAll::decode_all(&msg.actual_data).unwrap();       // TODO: don't unwrap
-        console.write(&message);
+        let message: redshirt_log_interface::ffi::DecodedLogMessage =
+            Decode::decode(EncodedMessage(msg.actual_data)).unwrap();       // TODO: don't unwrap
+        console.write(&message.message());
         console.write("\n");
     }
 }

--- a/modules/x86-pci/src/main.rs
+++ b/modules/x86-pci/src/main.rs
@@ -119,7 +119,7 @@ async unsafe fn read_bus_pci_devices(bus_idx: u8) -> Vec<redshirt_pci_interface:
 
             redshirt_log_interface::log(
                 redshirt_log_interface::Level::Info,
-                format!("PCI device: {} - {}", vendor_name, device_name)
+                &format!("PCI device: {} - {}", vendor_name, device_name)
             );
 
             // TODO: wrong; need to enumerate other PCI buses


### PR DESCRIPTION
Here's the hello world WASM after (without all the runtime garbage around):

```wast
  (func $_ZN11hello_world4main17hbb01e2f79c3e02adE (type $t0)
    (local $l0 i32)
    get_global $g0
    i32.const 48
    i32.sub
    tee_local $l0
    set_global $g0
    get_local $l0
    i32.const 2
    i32.store8 offset=15
    get_local $l0
    i32.const 25
    i32.add
    i32.const 1048600
    i64.extend_u/i32
    i64.const 51539607552
    i64.or
    i64.store align=1
    get_local $l0
    get_local $l0
    i32.const 15
    i32.add
    i64.extend_u/i32
    i64.const 4294967296
    i64.or
    i64.store offset=17 align=1
    get_local $l0
    i32.const 1
    i32.store8 offset=16
    i32.const 1054212
    get_local $l0
    i32.const 16
    i32.add
    i32.const 1
    i32.or
    i32.const 2
    i32.const 0
    i32.const 1
    get_local $l0
    i32.const 40
    i32.add
    call $_ZN27redshirt_syscalls_interface3ffi12emit_message17h508280f1400e36efE
    drop
    get_local $l0
    i32.const 48
    i32.add
    set_global $g0)
```