### PR TITLE
Fix the key of the bootnode

### DIFF
--- a/.github/node-deploy-kube-config.yml
+++ b/.github/node-deploy-kube-config.yml
@@ -13,6 +13,14 @@ spec:
       port: 30333
       targetPort: 30333
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: p2p-loader-private-key
+type: Opaque
+data:
+  private_key: cCzPG7dMwMIOJ25gBUFgC1cooYQmiZ54HKfzH2W8AmQ=   # TODO: that's not exactly "secret"
+---
 apiVersion: apps/v1
 kind: Deployment # TODO: shouldn't that be a StatefulSet?
 metadata:
@@ -37,6 +45,11 @@ spec:
         env:
         - name: RUST_LOG
           value: p2p_loader=TRACE
+        - name: PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: p2p-loader-private-key # TODO: we need one key per node :facepalm:
+              key: private_key
         ports:
         - containerPort: 30333
           protocol: TCP

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -126,6 +126,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "p2p-loader"
 version = "0.1.0"
 dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libp2p-core 0.14.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2268,6 +2274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+"checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
 "checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"

--- a/modules/p2p-loader/Cargo.toml
+++ b/modules/p2p-loader/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+base64 = { version = "0.11.0", default-features = false, features = ["alloc"] }
 futures = "0.3"
 libp2p-core = "0.14.0-alpha.1"
 libp2p-kad = "0.14.0-alpha.1"

--- a/modules/p2p-loader/src/bin/modules-loader.rs
+++ b/modules/p2p-loader/src/bin/modules-loader.rs
@@ -29,7 +29,7 @@ async fn async_main() {
         .await
         .unwrap();
 
-    let mut network = Network::start();
+    let mut network = Network::start(Default::default());
 
     loop {
         let next_interface = redshirt_syscalls::next_interface_message();

--- a/modules/p2p-loader/src/bin/passive-node.rs
+++ b/modules/p2p-loader/src/bin/passive-node.rs
@@ -13,7 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-use p2p_loader::Network;
+use p2p_loader::{Network, NetworkConfig};
+use std::env;
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
@@ -28,7 +29,19 @@ fn main() {
 }
 
 async fn async_main() {
-    let mut network = Network::<std::convert::Infallible>::start(); // TODO: use `!`
+    let config = NetworkConfig {
+        private_key: if let Ok(key) = env::var("PRIVATE_KEY") {
+            let bytes = base64::decode(&key).unwrap();
+            assert_eq!(bytes.len(), 32);
+            let mut out = [0; 32];
+            out.copy_from_slice(&bytes);
+            Some(out)
+        } else {
+            None
+        },
+    };
+
+    let mut network = Network::<std::convert::Infallible>::start(config); // TODO: use `!`
 
     loop {
         let _ = network.next_event().await;


### PR DESCRIPTION
Pass a private key to Kubernetes so that the bootnode's public key stops changing.

Note: yeah the private key is clearly visible in the repo (it's only encoded in base64). It doesn't really matter, as you can't actually achieve anything with a MITM attack apart from denial of service. If this gets serious, I'll switch to a key that is actually secret.