### PR TITLE
Make build_wasm_module! accept a second parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,12 @@ jobs:
       run: |
         apt-get update
         apt-get install -y lld
+    - name: Install a recent version of clang
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+        echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" >> /etc/apt/sources.list
+        apt-get update
+        apt-get install -y clang-9
     - name: Cache cargo registry
       uses: actions/cache@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: rust
+      env:
+        CC: clang-9
     strategy:
       matrix:
         target: [x86_64-multiboot2, arm-freestanding]

--- a/core-proc-macros/src/lib.rs
+++ b/core-proc-macros/src/lib.rs
@@ -46,13 +46,40 @@ pub fn wat_to_bin(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
 }
 
 /// Compiles a WASM module and includes it similar to `include_bytes!`.
+///
 /// Must be passed the path to a directory containing a `Cargo.toml`.
+/// Can be passed an optional second argument containing the binary name to compile. Mandatory if
+/// the package contains multiple binaries.
+// TODO: show better errors
 #[cfg(feature = "nightly")]
 #[proc_macro_hack::proc_macro_hack]
 pub fn build_wasm_module(tokens: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    // Find the absolute path requested by the user.
-    let wasm_crate_path = {
-        let macro_param = syn::parse_macro_input!(tokens as syn::LitStr);
+    // Find the absolute path requested by the user, and optionally the binary target.
+    let (wasm_crate_path, requested_bin_target) = {
+        struct Params {
+            path: String,
+            bin_target: Option<String>,
+        }
+
+        impl syn::parse::Parse for Params {
+            fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+                let path: syn::LitStr = input.parse()?;
+                let bin_target = if input.is_empty() {
+                    None
+                } else {
+                    let _: syn::Token![,] = input.parse()?;
+                    let bin_target: syn::LitStr = input.parse()?;
+                    Some(bin_target)
+                };
+
+                Ok(Params {
+                    path: path.value(),
+                    bin_target: bin_target.map(|s| s.value()),
+                })
+            }
+        }
+
+        let macro_params = syn::parse_macro_input!(tokens as Params);
         let macro_call_file = {
             // We go through the stack of Spans until we find one with a file path.
             let mut span = proc_macro::Span::call_site();
@@ -65,7 +92,10 @@ pub fn build_wasm_module(tokens: proc_macro::TokenStream) -> proc_macro::TokenSt
             }
         };
 
-        macro_call_file.join(macro_param.value())
+        (
+            macro_call_file.join(macro_params.path),
+            macro_params.bin_target,
+        )
     };
 
     // Get the package ID of the package requested by the user.
@@ -87,7 +117,7 @@ pub fn build_wasm_module(tokens: proc_macro::TokenStream) -> proc_macro::TokenSt
     };
 
     // Determine the path to the `.wasm` and `.d` files that Cargo will generate.
-    let (wasm_output, dependencies_output) = {
+    let (wasm_output, dependencies_output, bin_target) = {
         let metadata = cargo_metadata::MetadataCommand::new()
             .current_dir(&wasm_crate_path)
             .no_deps()
@@ -102,20 +132,39 @@ pub fn build_wasm_module(tokens: proc_macro::TokenStream) -> proc_macro::TokenSt
             .targets
             .iter()
             .filter(|t| t.kind.iter().any(|k| k == "bin"));
-        let bin_target = bin_targets_iter.next().unwrap();
-        assert!(bin_targets_iter.next().is_none());
+        let bin_target = if let Some(requested_bin_target) = requested_bin_target {
+            match bin_targets_iter.find(|t| t.name == requested_bin_target) {
+                Some(t) => t.name.clone(),
+                None => panic!("Can't find binary target {:?}", requested_bin_target),
+            }
+        } else {
+            let target = bin_targets_iter.next().unwrap();
+            if bin_targets_iter.next().is_some() {
+                panic!(
+                    "Multiple binary targets available, please mention the one you want: {:?}",
+                    package
+                        .targets
+                        .iter()
+                        .filter(|t| t.kind.iter().any(|k| k == "bin"))
+                        .map(|t| &t.name)
+                        .collect::<Vec<_>>()
+                );
+            }
+            target.name.clone()
+        };
         let base = metadata
             .target_directory
             .join("wasm32-unknown-unknown")
             .join("release");
-        let wasm = base.join(format!("{}.wasm", bin_target.name));
-        let deps = base.join(format!("{}.d", bin_target.name));
-        (wasm, deps)
+        let wasm = base.join(format!("{}.wasm", bin_target));
+        let deps = base.join(format!("{}.d", bin_target));
+        (wasm, deps, bin_target)
     };
 
     // Actually build the module.
     assert!(Command::new("cargo")
         .arg("rustc")
+        .args(&["--bin", &bin_target])
         .arg("--release")
         .args(&["--target", "wasm32-unknown-unknown"])
         .arg("--")

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -57,6 +57,10 @@ impl Kernel {
         let mut system_builder = redshirt_core::system::SystemBuilder::new()
             .with_native_program(crate::hardware::HardwareHandler::new())
             .with_native_program(crate::random::native::RandomNativeProgram::new())
+            .with_startup_process(build_wasm_module!(
+                "../../../modules/p2p-loader",
+                "passive-node"
+            ))
             .with_startup_process(build_wasm_module!("../../../modules/hello-world"));
 
         // TODO: use a better system than cfgs


### PR DESCRIPTION
Allows putting the `p2p-loader` in the standalone kernel.