### PR TITLE
Add a PlatformSpecific trait

### DIFF
--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -43,6 +43,9 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// Returns the number of CPUs available.
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32;
 
+    /// Blocks the current core until the given `Future` produces a value.
+    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet;
+
     /// Returns the number of nanoseconds that happened since an undeterminate moment in time.
     fn monotonic_clock(self: Pin<&Self>) -> u128;
     /// Returns a `Future` that fires when the monotonic clock reaches the given value.

--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -28,7 +28,7 @@
 //! After everything has been initialized, the entry point creates a struct that implements the
 //! [`PlatformSpecific`] trait, and initializes and runs a [`Kernel`](crate::kernel::Kernel).
 
-use core::{future::Future, pin::Pin};
+use core::{future::Future, num::NonZeroU32, pin::Pin};
 
 mod arm;
 mod x86_64;
@@ -39,6 +39,9 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// `Future` that fires when the monotonic clock reaches a certain value.
     // TODO: remove `'static` requirement
     type TimerFuture: Future<Output = ()> + Send + 'static;
+
+    /// Returns the number of CPUs available.
+    fn num_cpus(self: Pin<&Self>) -> NonZeroU32;
 
     /// Returns the number of nanoseconds that happened since an undeterminate moment in time.
     fn monotonic_clock(self: Pin<&Self>) -> u128;

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -17,7 +17,7 @@
 
 use crate::arch::PlatformSpecific;
 
-use core::{iter, pin::Pin};
+use core::{iter, num::NonZeroU32, pin::Pin};
 use futures::prelude::*;
 
 mod misc;
@@ -96,6 +96,10 @@ struct PlatformSpecificImpl;
 
 impl PlatformSpecific for PlatformSpecificImpl {
     type TimerFuture = future::Pending<()>;
+
+    fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
+        NonZeroU32::new(1).unwrap()
+    }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {
         // TODO: implement correctly

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -15,7 +15,10 @@
 
 #![cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 
-use core::{future::Future, iter};
+use crate::arch::PlatformSpecific;
+
+use core::{iter, pin::Pin};
+use futures::prelude::*;
 
 mod misc;
 mod panic;
@@ -84,52 +87,57 @@ fn cpu_enter(_r0: u32, _r1: u32, _r2: u32) -> ! {
         asm!("mcr p15, 0, $0, c9, c12, 3"::"r"(0x8000000fu32)::"volatile");
     }
 
-    let kernel = crate::kernel::Kernel::init(crate::kernel::KernelConfig {
-        num_cpus: 1,
-        ..Default::default()
-    });
-
+    let kernel = crate::kernel::Kernel::init(PlatformSpecificImpl);
     kernel.run()
+}
+
+/// Implementation of [`PlatformSpecific`].
+struct PlatformSpecificImpl;
+
+impl PlatformSpecific for PlatformSpecificImpl {
+    type TimerFuture = future::Pending<()>;
+
+    fn monotonic_clock(self: Pin<&Self>) -> u128 {
+        // TODO: implement correctly
+        0xdeadbeefu128
+    }
+
+    fn timer(self: Pin<&Self>, clock_value: u128) -> Self::TimerFuture {
+        future::pending()
+    }
+
+    unsafe fn write_port_u8(self: Pin<&Self>, _: u32, _: u8) -> Result<(), ()> {
+        Err(())
+    }
+
+    unsafe fn write_port_u16(self: Pin<&Self>, _: u32, _: u16) -> Result<(), ()> {
+        Err(())
+    }
+
+    unsafe fn write_port_u32(self: Pin<&Self>, _: u32, _: u32) -> Result<(), ()> {
+        Err(())
+    }
+
+    unsafe fn read_port_u8(self: Pin<&Self>, _: u32) -> Result<u8, ()> {
+        Err(())
+    }
+
+    unsafe fn read_port_u16(self: Pin<&Self>, _: u32) -> Result<u16, ()> {
+        Err(())
+    }
+
+    unsafe fn read_port_u32(self: Pin<&Self>, _: u32) -> Result<u32, ()> {
+        Err(())
+    }
 }
 
 // TODO: no_mangle and naked because it's called at initialization; attributes should eventually be removed
 #[no_mangle]
 #[naked]
-// TODO: define the semantics of that
-pub fn halt() -> ! {
+fn halt() -> ! {
     unsafe {
         loop {
             asm!(r#"wfe"#);
         }
     }
-}
-
-/// Returns the number of nanoseconds that happened since an undeterminate moment in time.
-// TODO: implement correctly
-pub fn monotonic_clock() -> u128 {
-    0xdeadbeefu128
-}
-
-/// Returns a `Future` that fires when the monotonic clock reaches the given value.
-// TODO: implement correctly
-pub fn timer(clock_value: u128) -> impl Future<Output = ()> {
-    futures::future::poll_fn(|_| core::task::Poll::Pending)
-}
-
-pub unsafe fn write_port_u8(port: u32, data: u8) {}
-
-pub unsafe fn write_port_u16(port: u32, data: u16) {}
-
-pub unsafe fn write_port_u32(port: u32, data: u32) {}
-
-pub unsafe fn read_port_u8(port: u32) -> u8 {
-    0
-}
-
-pub unsafe fn read_port_u16(port: u32) -> u16 {
-    0
-}
-
-pub unsafe fn read_port_u32(port: u32) -> u32 {
-    0
 }

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -20,6 +20,7 @@ use crate::arch::PlatformSpecific;
 use core::{iter, num::NonZeroU32, pin::Pin};
 use futures::prelude::*;
 
+mod executor;
 mod misc;
 mod panic;
 
@@ -99,6 +100,10 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         NonZeroU32::new(1).unwrap()
+    }
+
+    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet {
+        executor::block_on(future)
     }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {

--- a/kernel/standalone/src/arch/arm/executor.rs
+++ b/kernel/standalone/src/arch/arm/executor.rs
@@ -1,0 +1,67 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+//! Futures executor that works on bare metal.
+
+// TODO: only works because we're single-CPU'ed at the moment
+
+use alloc::sync::Arc;
+use core::future::Future;
+use core::sync::atomic;
+use core::task::{Context, Poll};
+use futures::task::{waker, ArcWake};
+
+/// Waits for the `Future` to resolve to a value.
+///
+/// This function is similar to [`futures::executor::block_on`].
+pub fn block_on<R>(future: impl Future<Output = R>) -> R {
+    futures::pin_mut!(future);
+
+    let local_wake = Arc::new(LocalWake {
+        woken_up: atomic::AtomicBool::new(false),
+    });
+
+    let waker = waker(local_wake.clone());
+    let mut context = Context::from_waker(&waker);
+
+    loop {
+        if let Poll::Ready(val) = Future::poll(future.as_mut(), &mut context) {
+            return val;
+        }
+
+        loop {
+            if local_wake
+                .woken_up
+                .compare_and_swap(true, false, atomic::Ordering::Acquire)
+            {
+                break;
+            }
+
+            // TODO: this is a draft; I don't really know well how ARM interrupts work
+            unsafe { asm!("wfe" :::: "volatile") }
+        }
+    }
+}
+
+struct LocalWake {
+    woken_up: atomic::AtomicBool,
+}
+
+impl ArcWake for LocalWake {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.woken_up.store(true, atomic::Ordering::Release);
+        // TODO: wake up original CPU, once we're multi-CPU'ed
+    }
+}

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -18,7 +18,7 @@
 use crate::arch::PlatformSpecific;
 
 use alloc::sync::Arc;
-use core::{convert::TryFrom as _, future::Future, ops::Range, pin::Pin};
+use core::{convert::TryFrom as _, future::Future, num::NonZeroU32, ops::Range, pin::Pin};
 use x86_64::registers::model_specific::Msr;
 use x86_64::structures::port::{PortRead as _, PortWrite as _};
 
@@ -123,6 +123,10 @@ struct PlatformSpecificImpl;
 
 impl PlatformSpecific for PlatformSpecificImpl {
     type TimerFuture = apic::TscTimerFuture;
+
+    fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
+        NonZeroU32::new(1).unwrap()
+    }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {
         // TODO: wrong unit; these are not nanoseconds

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -25,6 +25,7 @@ use x86_64::structures::port::{PortRead as _, PortWrite as _};
 mod acpi;
 mod apic;
 mod boot_link;
+mod executor;
 mod interrupts;
 mod panic;
 
@@ -126,6 +127,10 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         NonZeroU32::new(1).unwrap()
+    }
+
+    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet {
+        executor::block_on(future)
     }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {

--- a/kernel/standalone/src/arch/x86_64/apic.rs
+++ b/kernel/standalone/src/arch/x86_64/apic.rs
@@ -114,7 +114,7 @@ pub struct ApicControl {
 impl ApicControl {
     /// Returns a `Future` that fires when the TSC (Timestamp Counter) is superior or equal to
     /// the given value.
-    pub fn register_tsc_timer(self: &Arc<Self>, value: u64) -> impl Future<Output = ()> {
+    pub fn register_tsc_timer(self: &Arc<Self>, value: u64) -> TscTimerFuture {
         TscTimerFuture {
             apic_control: self.clone(),
             tsc_value: value,

--- a/kernel/standalone/src/hardware.rs
+++ b/kernel/standalone/src/hardware.rs
@@ -18,9 +18,9 @@
 //! The `hardware` interface is particular in that it can only be implemented using a "hosted"
 //! implementation.
 
-use crate::arch;
+use crate::arch::PlatformSpecific;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{convert::TryFrom as _, pin::Pin, sync::atomic};
 use crossbeam_queue::SegQueue;
 use futures::prelude::*;
@@ -34,9 +34,11 @@ use redshirt_hardware_interface::ffi::{
 use spin::Mutex;
 
 /// State machine for `hardware` interface messages handling.
-pub struct HardwareHandler {
+pub struct HardwareHandler<TPlat> {
     /// If true, we have sent the interface registration message.
     registered: atomic::AtomicBool,
+    /// Platform-specific hooks.
+    platform_specific: Pin<Arc<TPlat>>,
     /// For each PID, a list of memory allocations.
     // TODO: optimize
     allocations: Mutex<HashMap<Pid, Vec<Vec<u8>>, BuildNoHashHasher<u64>>>,
@@ -44,18 +46,22 @@ pub struct HardwareHandler {
     pending_messages: SegQueue<(MessageId, Result<EncodedMessage, ()>)>,
 }
 
-impl HardwareHandler {
+impl<TPlat> HardwareHandler<TPlat> {
     /// Initializes the new state machine for hardware accesses.
-    pub fn new() -> Self {
+    pub fn new(platform_specific: Pin<Arc<TPlat>>) -> Self {
         HardwareHandler {
             registered: atomic::AtomicBool::new(false),
+            platform_specific,
             allocations: Mutex::new(HashMap::default()),
             pending_messages: SegQueue::new(),
         }
     }
 }
 
-impl<'a> NativeProgramRef<'a> for &'a HardwareHandler {
+impl<'a, TPlat> NativeProgramRef<'a> for &'a HardwareHandler<TPlat>
+where
+    TPlat: PlatformSpecific,
+{
     type Future =
         Pin<Box<dyn Future<Output = NativeProgramEvent<Self::MessageIdWrite>> + Send + 'a>>;
     type MessageIdWrite = DummyMessageIdWrite;
@@ -95,7 +101,9 @@ impl<'a> NativeProgramRef<'a> for &'a HardwareHandler {
                 let mut response = Vec::with_capacity(operations.len());
                 for operation in operations {
                     unsafe {
-                        if let Some(outcome) = perform_operation(operation) {
+                        if let Some(outcome) =
+                            perform_operation(self.platform_specific.as_ref(), operation)
+                        {
                             response.push(outcome);
                         }
                     }
@@ -159,7 +167,13 @@ impl<'a> NativeProgramRef<'a> for &'a HardwareHandler {
     }
 }
 
-unsafe fn perform_operation(operation: Operation) -> Option<HardwareAccessResponse> {
+unsafe fn perform_operation<TPlat>(
+    platform_specific: Pin<&TPlat>,
+    operation: Operation,
+) -> Option<HardwareAccessResponse>
+where
+    TPlat: PlatformSpecific,
+{
     match operation {
         Operation::PhysicalMemoryWriteU8 { address, data } => {
             if let Ok(mut address) = usize::try_from(address) {
@@ -243,25 +257,25 @@ unsafe fn perform_operation(operation: Operation) -> Option<HardwareAccessRespon
             Some(HardwareAccessResponse::PhysicalMemoryReadU32(out))
         }
         Operation::PortWriteU8 { port, data } => {
-            arch::write_port_u8(port, data);
+            let _ = platform_specific.write_port_u8(port, data);
             None
         }
         Operation::PortWriteU16 { port, data } => {
-            arch::write_port_u16(port, data);
+            let _ = platform_specific.write_port_u16(port, data);
             None
         }
         Operation::PortWriteU32 { port, data } => {
-            arch::write_port_u32(port, data);
+            let _ = platform_specific.write_port_u32(port, data);
             None
         }
-        Operation::PortReadU8 { port } => {
-            Some(HardwareAccessResponse::PortReadU8(arch::read_port_u8(port)))
-        }
+        Operation::PortReadU8 { port } => Some(HardwareAccessResponse::PortReadU8(
+            platform_specific.read_port_u8(port).unwrap_or(0),
+        )),
         Operation::PortReadU16 { port } => Some(HardwareAccessResponse::PortReadU16(
-            arch::read_port_u16(port),
+            platform_specific.read_port_u16(port).unwrap_or(0),
         )),
         Operation::PortReadU32 { port } => Some(HardwareAccessResponse::PortReadU32(
-            arch::read_port_u32(port),
+            platform_specific.read_port_u32(port).unwrap_or(0),
         )),
     }
 }

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -17,7 +17,7 @@
 //!
 //! # Usage
 //!
-//! - Create a [`KernelConfig`] struct indicating the configuration.
+//! - Create a type that implements the [`PlatformSpecific`] trait.
 //! - From one CPU, create a [`Kernel`] with [`Kernel::init`].
 //! - Share the newly-created [`Kernel`] between CPUs, and call [`Kernel::run`] once for each CPU.
 //!

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -90,7 +90,7 @@ where
         loop {
             // TODO: ideally the entire function would be async, and this would be an `await`,
             // but async functions don't work on no_std yet
-            match crate::executor::block_on(system.run()) {
+            match self.platform_specific.as_ref().block_on(system.run()) {
                 redshirt_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {
                     //console.write(&format!("Program finished {:?} => {:?}\n", pid, outcome));
                 }

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -28,7 +28,6 @@ extern crate alloc;
 extern crate rlibc;
 
 mod arch;
-mod executor;
 mod hardware;
 mod kernel;
 mod mem_alloc;


### PR DESCRIPTION
Adds a `PlatformSpecific` trait in the `arch` module of the standalone kernel.

This allows properly defining how the functions in `arch` must behave.