### PR TITLE
Enable stack probes on x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,9 +573,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3705e6d8ce20b80fde2ae549e69b91e958653f2d0aefdc8867e8432c840fb24"
+checksum = "47de1a43fad0250ee197e9e124e5b5deab3d7b39d4428ae8a6d741ceb340c362"
 dependencies = [
  "spin",
 ]

--- a/x86_64-multiboot2.json
+++ b/x86_64-multiboot2.json
@@ -21,7 +21,7 @@
     },
     "relocation-model": "static",
     "singlethread": true,
-    "stack-probes": false,
+    "stack-probes": true,
     "target-c-int-width": "32",
     "target-endian": "little",
     "target-pointer-width": "64",


### PR DESCRIPTION
cc #73

> The proper solution is stack probes, but I don't know how technically possible that is.

Actually quite easy. The `__rust_probestack` function is provided by `compiler_builtins`.

Note that this doesn't add any protection. We still need to properly setup paging.
