### PR TITLE
Fix the start address on raspi

### DIFF
--- a/arm-freestanding.ld
+++ b/arm-freestanding.ld
@@ -1,12 +1,12 @@
 ENTRY(_entry_point)
 
 SECTIONS {
-    . = 0x8000;
+    . = 0x10000;
     .text : AT(ADDR(.text)) {
         _entry_point = .;
         /* Same as above, jump to the address of `_start` */
-        /* TODO: this always fails, no clue why: ASSERT((((_start - 0x8000) >> 2) - 2) == (((_start >> 2) - 2) & 0x1FFFFFF), "_start too far away") */
-        LONG(0xea000000 | ((((_start - 0x8000) >> 2) - 2) & 0x1FFFFFF))
+        /* TODO: this always fails, no clue why: ASSERT((((_start - 0x10000) >> 2) - 2) == (((_start >> 2) - 2) & 0x1FFFFFF), "_start too far away") */
+        LONG(0xea000000 | ((((_start - 0x10000) >> 2) - 2) & 0x1FFFFFF))
 
         *(.text*)
         *(.rodata*)


### PR DESCRIPTION
Eventually the code should be PIC (cc #282) but in the meanwhile this fixes the address where the kernel gets loaded.
