### PR TITLE
Implement fd_write for WASI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,7 @@ dependencies = [
  "redshirt-core-proc-macros",
  "redshirt-interface-interface",
  "redshirt-loader-interface",
+ "redshirt-log-interface",
  "redshirt-random-interface",
  "redshirt-syscalls",
  "redshirt-threads-interface",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro-hack = "0.5.11"
 redshirt-core-proc-macros = { path = "../core-proc-macros" }
 redshirt-interface-interface = { path = "../interfaces/interface", default-features = false }
 redshirt-loader-interface = { path = "../interfaces/loader", default-features = false }
+redshirt-log-interface = { path = "../interfaces/log", default-features = false }
 redshirt-random-interface = { path = "../interfaces/random", default-features = false }
 redshirt-syscalls = { path = "../interfaces/syscalls", default-features = false }
 redshirt-threads-interface = { path = "../interfaces/threads", default-features = false }

--- a/core/src/extrinsics/wasi.rs
+++ b/core/src/extrinsics/wasi.rs
@@ -194,7 +194,7 @@ fn fd_write(
 ) -> ExtrinsicsAction {
     let fd = params.next().unwrap();
     // TODO: return error if wrong fd
-    assert!(fd == RuntimeValue::I32(1) || fd == RuntimeValue::I32(2));      // either stdout or stderr
+    assert!(fd == RuntimeValue::I32(1) || fd == RuntimeValue::I32(2)); // either stdout or stderr
 
     // Get a list of pointers and lengths to write.
     // Elements 0, 2, 4, 6, ... in that list are pointers, and elements 1, 3, 5, 7, ... are
@@ -212,7 +212,8 @@ fn fd_write(
 
     let mut total_written = 0;
     let mut encoded_message = Vec::new();
-    if fd == RuntimeValue::I32(2) { // TODO: handle better?
+    if fd == RuntimeValue::I32(2) {
+        // TODO: handle better?
         encoded_message.push(4); // ERROR log level.
     } else {
         encoded_message.push(2); // INFO log level.

--- a/modules/rpi-framebuffer/src/main.rs
+++ b/modules/rpi-framebuffer/src/main.rs
@@ -22,13 +22,6 @@ mod mailbox;
 mod property;
 
 fn main() {
-    std::panic::set_hook(Box::new(|info| {
-        redshirt_log_interface::log(
-            redshirt_log_interface::Level::Error,
-            &format!("Panic: {}\n", info),
-        );
-    }));
-
     redshirt_syscalls::block_on(async_main());
 }
 

--- a/modules/x86-log/src/main.rs
+++ b/modules/x86-log/src/main.rs
@@ -20,24 +20,6 @@ use redshirt_syscalls::{Decode, EncodedMessage};
 use std::{convert::TryFrom as _, mem};
 
 fn main() {
-    std::panic::set_hook(Box::new(move |panic_info| {
-        redshirt_syscalls::block_on(async move {
-            // TODO: make this code alloc-free?
-
-            let mut console = Console {
-                cursor_x: 0,
-                cursor_y: 0,
-                screen_width: 80,
-                screen_height: 25,
-                ops_buffer: redshirt_hardware_interface::HardwareWriteOperationsBuilder::new(),
-            };
-
-            console.write("x86-log has panicked\n", 0xc).await;
-            console.write(&panic_info.to_string(), 0xc).await;
-            console.flush();
-        });
-    }));
-
     redshirt_syscalls::block_on(async_main());
 }
 


### PR DESCRIPTION
Implements `fd_write` again. Allows seeing the panic messages of modules without the module having to call `std::panic::set_hook`.

As such, I also removed the calls to `set_hook`.
