### PR TITLE
Don't make APs panic in kernel::run

### DIFF
--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -52,7 +52,9 @@ where
     pub fn run(&self) -> ! {
         // We only want a single CPU to run for now.
         if self.running.swap(true, Ordering::SeqCst) {
-            panic!(); // TODO:
+            self.platform_specific
+                .as_ref()
+                .block_on(futures::future::pending::<()>());
         }
 
         let mut system_builder = redshirt_core::system::SystemBuilder::new()


### PR DESCRIPTION
No longer show a panic message when a secondary processor reaches `Kernel::run`.
This is benign, but was always annoying.