### PR TITLE
Fix bug in register_message_waker

### DIFF
--- a/interfaces/syscalls/src/block_on.rs
+++ b/interfaces/syscalls/src/block_on.rs
@@ -59,7 +59,7 @@ pub(crate) fn register_message_waker(message_id: MessageId, waker: Waker) -> Wak
 
     let index = state.wakers.insert(Some(waker));
 
-    if index <= state.message_ids.len() {
+    if state.message_ids.len() <= index {
         state.message_ids.resize(index + 1, 0);
     }
 


### PR DESCRIPTION
It's amazing.

When I wrote this code I somehow felt that there was something wrong but couldn't pinpoint what.

And earlier when debugging a panic that was coming from the `state.message_ids[index] = ...` below, I read this code multiple times and still couldn't figure out what was wrong. It's only after I added `println!`s everywhere that I realized that we would never enter the `if`.