### PR TITLE
Work on the p2p loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly-2020-03-12
         target: wasm32-wasi
         override: true
     - name: Install a recent version of clang
@@ -109,7 +109,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly-2020-03-12
         target: wasm32-wasi
         override: true
     - name: Download WASM modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,8 @@ jobs:
         path: modules/target
         key: passive-node-check-target-${{ hashFiles('modules/Cargo.lock') }}
     - name: Check peer-to-peer passive node
-      run: cargo check --manifest-path ./modules/Cargo.toml --package p2p-loader --bin passive-node --locked --verbose
-      
+      run: cargo check --manifest-path ./modules/Cargo.toml --package p2p-loader --bin passive-node --locked --verbose --all-features
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,46 +100,6 @@ jobs:
     - name: Run tests
       run: cargo test --workspace --exclude redshirt-standalone-kernel --exclude redshirt-core-proc-macros --locked --verbose
 
-  build-hosted-windows:
-    name: Build hosted kernel on Windows
-    needs: build-modules
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly-2020-03-12
-        target: wasm32-wasi
-        override: true
-    - name: Download WASM modules
-      uses: actions/download-artifact@v1
-      with:
-        name: wasm-modules
-        path: modules/target/wasm32-wasi/release
-    - name: Cache cargo registry
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/registry
-        key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('Cargo.lock') }}
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
-    - name: Build CLI kernel
-      run: cargo rustc --release --package redshirt-cli-kernel --locked --verbose -- -Ctarget-feature=+crt-static
-    - name: Upload generated kernel
-      uses: actions/upload-artifact@master
-      with:
-        name: cli-kernel-windows
-        path: target/release/redshirt-cli-kernel.exe
-
   build-standalone:
     name: Build standalone kernel
     needs: build-modules

--- a/core/src/system.rs
+++ b/core/src/system.rs
@@ -183,7 +183,9 @@ impl System {
                     if self.loading_programs.borrow_mut().remove(&message_id) {
                         let redshirt_loader_interface::ffi::LoadResponse { result } =
                             Decode::decode(response.unwrap()).unwrap();
-                        let module = Module::from_bytes(&result.unwrap()).unwrap();
+                        // TODO: don't unwrap
+                        let module = Module::from_bytes(&result.expect("loader returned error"))
+                            .expect("module isn't proper wasm");
                         match self.core.execute(&module) {
                             Ok(_) => {}
                             Err(_) => panic!(),

--- a/interfaces/loader/src/ffi.rs
+++ b/interfaces/loader/src/ffi.rs
@@ -25,6 +25,7 @@ pub const INTERFACE: InterfaceHash = InterfaceHash::from_raw_hash([
 
 #[derive(Debug, Encode, Decode)]
 pub enum LoaderMessage {
+    /// Load the data corresponding to the blake3 hash passed as parameter.
     Load([u8; 32]),
 }
 

--- a/kernel/cli/Cargo.toml
+++ b/kernel/cli/Cargo.toml
@@ -10,7 +10,7 @@ default-run = "redshirt-cli-kernel"
 [dependencies]
 async-std = "1.3"
 futures = "0.3.1"
-redshirt-core = { path = "../../core" }
+redshirt-core = { path = "../../core", features = ["nightly"] }
 redshirt-log-hosted = { path = "../hosted-log" }
 redshirt-random-hosted = { path = "../hosted-random" }
 redshirt-syscalls = { path = "../../interfaces/syscalls" }

--- a/kernel/cli/src/main.rs
+++ b/kernel/cli/src/main.rs
@@ -15,6 +15,7 @@
 
 #![deny(intra_doc_link_resolution_failure)]
 
+use redshirt_core::{build_wasm_module, module::ModuleHash};
 use std::{fs, path::PathBuf, process};
 use structopt::StructOpt;
 
@@ -22,8 +23,28 @@ use structopt::StructOpt;
 #[structopt(name = "redshirt-cli", about = "Redshirt modules executor.")]
 struct CliOptions {
     /// WASM file to run.
-    #[structopt(parse(from_os_str))]
-    wasm_file: PathBuf,
+    #[structopt(long, parse(from_os_str))]
+    module_path: Vec<PathBuf>,
+
+    /// WASM file to run in the background.
+    ///
+    /// Contrary to `module_path`, the kernel will not stop if this module stops.
+    #[structopt(long, parse(from_os_str))]
+    background_module_path: Vec<PathBuf>,
+
+    /// Base58 encoding of the blake3 hash of a module to run.
+    ///
+    /// The module will be fetched from the public network.
+    #[structopt(long, parse(try_from_str = ModuleHash::from_base58))]
+    module_hash: Vec<ModuleHash>,
+
+    /// Base58 encoding of the blake3 hash of a module to run in the background.
+    ///
+    /// The module will be fetched from the public network.
+    ///
+    /// Contrary to `module_hash`, the kernel will not stop if this module stops.
+    #[structopt(long, parse(try_from_str = ModuleHash::from_base58))]
+    background_module_hash: Vec<ModuleHash>,
 }
 
 fn main() {
@@ -31,35 +52,69 @@ fn main() {
 }
 
 async fn async_main() {
-    let cli_requested_process = {
-        let cli_opts = CliOptions::from_args();
-        let wasm_file_content = fs::read(cli_opts.wasm_file).expect("failed to read input file");
-        redshirt_core::module::Module::from_bytes(&wasm_file_content)
-            .expect("failed to parse input file")
-    };
+    let cli_opts = CliOptions::from_args();
+
+    let mut cli_requested_processes = Vec::new();
+
+    for module_path in cli_opts.module_path {
+        let wasm_file_content = fs::read(module_path).expect("failed to read input file");
+        let module = redshirt_core::module::Module::from_bytes(&wasm_file_content)
+            .expect("failed to parse input file");
+        cli_requested_processes.push((module, true));
+    }
+
+    for module_path in cli_opts.background_module_path {
+        let wasm_file_content = fs::read(module_path).expect("failed to read input file");
+        let module = redshirt_core::module::Module::from_bytes(&wasm_file_content)
+            .expect("failed to parse input file");
+        cli_requested_processes.push((module, false));
+    }
 
     let system = redshirt_core::system::SystemBuilder::new()
         .with_native_program(redshirt_time_hosted::TimerHandler::new())
         .with_native_program(redshirt_tcp_hosted::TcpHandler::new())
         .with_native_program(redshirt_log_hosted::LogHandler::new())
         .with_native_program(redshirt_random_hosted::RandomNativeProgram::new())
+        .with_startup_process(build_wasm_module!(
+            "../../../modules/p2p-loader",
+            "modules-loader"
+        ))
+        .with_main_programs(cli_opts.module_hash)
+        .with_main_programs(cli_opts.background_module_hash)
         .build();
 
-    let cli_pid = system.execute(&cli_requested_process);
+    let mut cli_pids = Vec::with_capacity(cli_requested_processes.len());
+    // TODO: should also contain the `module_hash`es
+    for (module, foreground) in cli_requested_processes {
+        let pid = system.execute(&module);
+        if foreground {
+            cli_pids.push(pid);
+        }
+    }
+
+    // TODO: uncomment after cli_pids contains the `module_hash`es
+    /*if cli_pids.is_empty() {
+        return;
+    }*/
 
     loop {
         let outcome = system.run().await;
         match outcome {
-            redshirt_core::system::SystemRunOutcome::ProgramFinished { pid, outcome }
-                if pid == cli_pid =>
-            {
-                process::exit(match outcome {
-                    Ok(_) => 0,
-                    Err(err) => {
-                        println!("{:?}", err);
-                        1
-                    }
-                });
+            redshirt_core::system::SystemRunOutcome::ProgramFinished {
+                pid,
+                outcome: Err(err),
+            } if cli_pids.iter().any(|p| *p == pid) => {
+                eprintln!("{:?}", err);
+                process::exit(1);
+            }
+            redshirt_core::system::SystemRunOutcome::ProgramFinished {
+                pid,
+                outcome: Ok(()),
+            } => {
+                cli_pids.retain(|p| *p != pid);
+                if cli_pids.is_empty() {
+                    process::exit(0);
+                }
             }
             _ => panic!(),
         }

--- a/kernel/hosted-tcp/src/lib.rs
+++ b/kernel/hosted-tcp/src/lib.rs
@@ -545,7 +545,11 @@ async fn listener_task(
     mut front_to_back: mpsc::UnboundedReceiver<FrontToBackListener>,
     mut back_to_front: mpsc::Sender<BackToFront>,
 ) {
-    let socket = TcpListener::bind(&local_socket_addr).await.unwrap(); // TODO: don't unwrap
+    let socket = match TcpListener::bind(&local_socket_addr).await {
+        Ok(socket) => socket,
+        Err(_) => return, // TODO: somehow report this
+    };
+
     let mut pending_sockets = VecDeque::new();
 
     loop {

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -133,15 +133,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993f74b4c99c1908d156b8d2e0fb6277736b0ecbd833982fd1241d39b2766a6"
 
 [[package]]
-name = "blake2"
-version = "0.8.1"
+name = "blake2b_simd"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
- "byte-tools",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
  "crypto-mac",
  "digest",
- "opaque-debug",
 ]
 
 [[package]]
@@ -197,16 +222,6 @@ checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
-
-[[package]]
-name = "bytes"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10004c15deb332055f7a4a208190aed362cf9a7c2f6ab70a305fba50e1105f38"
@@ -255,6 +270,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "crossbeam-channel"
@@ -391,6 +412,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "filetime"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +441,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 
 [[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,12 +474,6 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
-name = "futures"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
@@ -520,7 +566,6 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
 dependencies = [
- "futures 0.1.29",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -532,7 +577,6 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io",
 ]
 
 [[package]]
@@ -541,8 +585,8 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3"
 dependencies = [
- "bytes 0.5.3",
- "futures 0.3.1",
+ "bytes",
+ "futures",
  "memchr",
  "pin-project",
 ]
@@ -610,7 +654,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-core",
  "futures-sink",
@@ -684,7 +728,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa",
 ]
@@ -695,7 +739,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "http",
 ]
 
@@ -703,7 +747,7 @@ dependencies = [
 name = "http-server"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "hyper",
  "log",
  "redshirt-log-interface",
@@ -732,7 +776,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -767,6 +811,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
 dependencies = [
  "autocfg 1.0.0",
+]
+
+[[package]]
+name = "inotify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -843,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+
+[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,21 +921,21 @@ checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 [[package]]
 name = "libp2p-core"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b874594c4b29de1a29f27871feba8e6cd13aa54a8a1e8f8c7cf3dfac5ca287c"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
  "asn1_der",
  "bs58",
  "ed25519-dalek",
+ "either",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1",
+ "futures",
  "futures-timer 3.0.2",
  "lazy_static",
  "libsecp256k1",
  "log",
+ "multihash",
  "multistream-select",
  "parity-multiaddr",
- "parity-multihash",
  "parking_lot",
  "pin-project",
  "prost",
@@ -884,19 +954,18 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464dc8412978d40f0286be72ed9ab5e0e1386a4a06e7f174526739b5c3c1f041"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
  "arrayvec",
- "bytes 0.5.3",
+ "bytes",
  "either",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1",
+ "futures",
  "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "parity-multihash",
+ "multihash",
  "prost",
  "prost-build",
  "rand",
@@ -911,12 +980,11 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8507b37ad0eed275efcde67a023c3d85af6c80768b193845b9288e848e1af95"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.3.1",
+ "futures",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -927,11 +995,10 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56126a204d7b3382bac163143ff4125a14570b3ba76ba979103d1ae1abed1923"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
- "bytes 0.5.3",
- "futures 0.3.1",
+ "bytes",
+ "futures",
  "futures_codec",
  "libp2p-core",
  "log",
@@ -945,10 +1012,9 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275471e7c0e88ae004660866cd54f603bd8bd1f4caef541a27f50dd8640c4d4c"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "libp2p-core",
  "log",
  "smallvec",
@@ -959,11 +1025,10 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e80ad4e3535345f3d666554ce347d3100453775611c05c60786bf9a1747a10"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
  "async-std",
- "futures 0.3.1",
+ "futures",
  "futures-timer 3.0.2",
  "get_if_addrs",
  "ipnet",
@@ -1052,6 +1117,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio-uds"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fbc227f7e2b1cb701f95404579ecb2668abbdd3c7ef7a6cbb3cc0d3b236869"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "digest",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,14 +1175,13 @@ checksum = "a97fbd5d00e0e37bfb10f433af8f5aaf631e739368dc9fc28286ca81ca4948dc"
 [[package]]
 name = "multistream-select"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f938ffe420493e77c8b6cbcc3f282283f68fc889c5dcbc8e51668d5f3a01ad94"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
- "bytes 0.5.3",
- "futures 0.1.29",
+ "bytes",
+ "futures",
  "log",
+ "pin-project",
  "smallvec",
- "tokio-io",
  "unsigned-varint",
 ]
 
@@ -1135,6 +1226,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,8 +1270,10 @@ name = "p2p-loader"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "blake3",
+ "bs58",
  "env_logger",
- "futures 0.3.1",
+ "futures",
  "libp2p-core",
  "libp2p-kad",
  "libp2p-mplex",
@@ -1170,6 +1281,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "log",
+ "notify",
  "parity-scale-codec",
  "redshirt-interface-interface",
  "redshirt-loader-interface",
@@ -1177,39 +1289,24 @@ dependencies = [
  "redshirt-syscalls",
  "redshirt-tcp-interface",
  "redshirt-time-interface",
+ "walkdir",
 ]
 
 [[package]]
 name = "parity-multiaddr"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77055f9e81921a8cc7bebeb6cded3d128931d51f1e3dd6251f0770a6d431477"
+source = "git+https://github.com/libp2p/rust-libp2p?rev=97a02950bb0b58ad9e01dacabc4d9a09c3e3954a#97a02950bb0b58ad9e01dacabc4d9a09c3e3954a"
 dependencies = [
  "arrayref",
  "bs58",
  "byteorder",
  "data-encoding",
- "parity-multihash",
+ "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint",
  "url",
-]
-
-[[package]]
-name = "parity-multihash"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1cd2ba02391b81367bec529fb209019d718684fdc8ad6a712c2b536e46f775"
-dependencies = [
- "blake2",
- "bytes 0.5.3",
- "rand",
- "sha-1",
- "sha2",
- "sha3",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -1279,18 +1376,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fca1c4ff21f60ca2d37b80d72b63dab823a9d19d3cda3a81d18bc03f0ba8c5"
+checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6544cd4e4ecace61075a6ec78074beeef98d58aa9a3d07d053d993b2946a90d6"
+checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1356,7 +1453,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "prost-derive",
 ]
 
@@ -1366,7 +1463,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "heck",
  "itertools",
  "log",
@@ -1397,7 +1494,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "prost",
 ]
 
@@ -1467,7 +1564,7 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 name = "redshirt-hardware-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "redshirt-syscalls",
 ]
@@ -1476,7 +1573,7 @@ dependencies = [
 name = "redshirt-interface-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "redshirt-syscalls",
 ]
@@ -1485,7 +1582,7 @@ dependencies = [
 name = "redshirt-loader-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "redshirt-syscalls",
 ]
@@ -1502,7 +1599,7 @@ dependencies = [
 name = "redshirt-pci-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "redshirt-syscalls",
 ]
@@ -1511,7 +1608,7 @@ dependencies = [
 name = "redshirt-syscalls"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "generic-array 0.13.2",
  "hashbrown",
  "lazy_static",
@@ -1526,7 +1623,7 @@ dependencies = [
 name = "redshirt-tcp-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "redshirt-syscalls",
  "tokio",
@@ -1536,7 +1633,7 @@ dependencies = [
 name = "redshirt-time-interface"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "parity-scale-codec",
  "pin-project",
  "redshirt-syscalls",
@@ -1621,8 +1718,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761d4727649dc004ee5555a0779afd53963efafd2218c969a2c5e323cdf73a09"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "static_assertions",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1728,7 +1834,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stub"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.1",
+ "futures",
  "redshirt-syscalls",
  "wee_alloc",
 ]
@@ -1825,21 +1931,10 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr",
  "pin-project-lite",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "log",
 ]
 
 [[package]]
@@ -1848,7 +1943,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -1927,11 +2022,11 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c689459fbaeb50e56c6749275f084decfd02194ac5852e6617d95d0d3cf02eaf"
+checksum = "f38e01ad4b98f042e166c1bf9a13f9873a99d79eaa171ce7ca81e6dd0f895d8a"
 dependencies = [
- "bytes 0.5.3",
+ "bytes",
  "futures_codec",
 ]
 
@@ -1963,6 +2058,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.8",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/modules/p2p-loader/Cargo.toml
+++ b/modules/p2p-loader/Cargo.toml
@@ -7,19 +7,23 @@ publish = false
 
 [dependencies]
 base64 = { version = "0.11.0", default-features = false, features = ["alloc"] }
+blake3 = { version = "0.1.1", default-features = false }
+bs58 = "0.3.0"
 futures = "0.3"
-libp2p-core = "0.16.0"
-libp2p-kad = "0.16.2"
-libp2p-mplex = "0.16.0"
-#libp2p-noise = "0.16.2"
-libp2p-plaintext = "0.16.0"
-libp2p-swarm = "0.16.0"
+libp2p-core = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
+libp2p-kad = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
+libp2p-mplex = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
+#libp2p-noise = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
+libp2p-plaintext = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
+libp2p-swarm = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
 log = "0.4"
+notify = { version = "4.0.15", optional = true }
 parity-scale-codec = "1.0.5"
+walkdir = "2.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.7.1"
-libp2p-tcp = "0.16.0"
+libp2p-tcp = { git = "https://github.com/libp2p/rust-libp2p", rev = "97a02950bb0b58ad9e01dacabc4d9a09c3e3954a" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 redshirt-interface-interface = { path = "../../interfaces/interface" }

--- a/modules/p2p-loader/Dockerfile
+++ b/modules/p2p-loader/Dockerfile
@@ -7,7 +7,7 @@ COPY . /build
 WORKDIR /build/modules/p2p-loader
 RUN apt-get update && apt-get install -y musl-tools
 RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo build --target x86_64-unknown-linux-musl --bin passive-node --release --verbose
+RUN cargo build --target x86_64-unknown-linux-musl --bin passive-node --release --verbose --all-features
 
 
 FROM alpine:latest

--- a/modules/p2p-loader/src/bin/modules-loader.rs
+++ b/modules/p2p-loader/src/bin/modules-loader.rs
@@ -19,6 +19,7 @@ use parity_scale_codec::DecodeAll;
 use std::time::Duration;
 
 fn main() {
+    redshirt_log_interface::init();
     redshirt_syscalls::block_on(async_main())
 }
 
@@ -63,6 +64,7 @@ async fn async_main() {
         let msg_data =
             redshirt_loader_interface::ffi::LoaderMessage::decode_all(&msg.actual_data.0).unwrap();
         let redshirt_loader_interface::ffi::LoaderMessage::Load(hash_to_load) = msg_data;
+        log::info!("loading {}", bs58::encode(hash_to_load).into_string());
         network.start_fetch(&hash_to_load, msg.message_id.unwrap());
     }
 }

--- a/modules/p2p-loader/src/bin/passive-node.rs
+++ b/modules/p2p-loader/src/bin/passive-node.rs
@@ -14,7 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use p2p_loader::{Network, NetworkConfig};
-use std::env;
+use std::{env, path::Path};
 
 #[cfg(target_arch = "wasm32")]
 fn main() {
@@ -29,17 +29,18 @@ fn main() {
 }
 
 async fn async_main() {
-    let config = NetworkConfig {
-        private_key: if let Ok(key) = env::var("PRIVATE_KEY") {
-            let bytes = base64::decode(&key).unwrap();
-            assert_eq!(bytes.len(), 32);
-            let mut out = [0; 32];
-            out.copy_from_slice(&bytes);
-            Some(out)
-        } else {
-            None
-        },
+    let mut config = NetworkConfig::default();
+    config.private_key = if let Ok(key) = env::var("PRIVATE_KEY") {
+        let bytes = base64::decode(&key).unwrap();
+        assert_eq!(bytes.len(), 32);
+        let mut out = [0; 32];
+        out.copy_from_slice(&bytes);
+        Some(out)
+    } else {
+        None
     };
+    // TODO: hack; use a CLI instead
+    config.watched_directory = Some(Path::new("../target/wasm32-wasi/release").to_owned());
 
     let mut network = Network::<std::convert::Infallible>::start(config); // TODO: use `!`
 

--- a/modules/p2p-loader/src/notifier.rs
+++ b/modules/p2p-loader/src/notifier.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use futures::prelude::*;
+use std::{fs, path::Path, time::Duration};
+use walkdir::WalkDir;
+
+/// Event that the notifier can produce.
+#[derive(Debug)]
+pub enum NotifierEvent {
+    /// Insert a value in the DHT.
+    InjectDht {
+        /// Key to insert.
+        hash: [u8; 32],
+        /// Data to insert.
+        data: Vec<u8>,
+    }, // TODO: more event? remove event?
+}
+
+/// Returns a stream of events about the given path in the file system.
+pub fn start_notifier(path: impl AsRef<Path>) -> impl Stream<Item = NotifierEvent> {
+    start_notifier_inner(path)
+}
+
+#[cfg(feature = "notify")]
+fn start_notifier_inner(path: impl AsRef<Path>) -> impl Stream<Item = NotifierEvent> {
+    use notify::Watcher as _;
+
+    let path = path.as_ref().to_owned();
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    tx.send(notify::DebouncedEvent::Rescan).unwrap();
+    let (mut async_tx, async_rx) = futures::channel::mpsc::channel(2);
+
+    let mut watcher = notify::watcher(tx, Duration::from_secs(5)).unwrap();
+    watcher
+        .watch(&path, notify::RecursiveMode::Recursive)
+        .unwrap();
+
+    std::thread::Builder::new()
+        .name("files-watcher".to_string())
+        .spawn(move || {
+            futures::executor::block_on(async move {
+                // Make sure that the watcher is kept alive inside the thread.
+                let _watcher = watcher;
+
+                loop {
+                    let files_to_try = match rx.recv().unwrap() {
+                        notify::DebouncedEvent::Write(path)
+                        | notify::DebouncedEvent::Create(path) => vec![path],
+                        notify::DebouncedEvent::Rescan => {
+                            let mut files = Vec::new();
+                            for entry in WalkDir::new(&path).into_iter().filter_map(|e| e.ok()) {
+                                let path = entry.path();
+                                if !path.is_file() {
+                                    continue;
+                                }
+                                files.push(path.to_owned());
+                            }
+                            files
+                        }
+                        notify::DebouncedEvent::Error(err, path) => {
+                            log::error!("Watcher error: {:?} for {:?}", err, path);
+                            continue;
+                        }
+                        _ => continue,
+                    };
+
+                    for path in files_to_try {
+                        let data = match fs::read(&path) {
+                            Ok(d) => d,
+                            Err(err) => {
+                                log::warn!("Unable to read content of {}: {}", path.display(), err);
+                                continue;
+                            }
+                        };
+
+                        if !can_be_wasm(&path, &data) {
+                            continue;
+                        }
+
+                        let hash = blake3::hash(&data);
+                        log::info!(
+                            "File {:?} has hash {:?}",
+                            path,
+                            bs58::encode(hash.as_bytes()).into_string()
+                        );
+                        if async_tx
+                            .send(NotifierEvent::InjectDht {
+                                hash: *hash.as_bytes(),
+                                data,
+                            })
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            })
+        })
+        .unwrap();
+
+    async_rx
+}
+
+#[cfg(not(feature = "notify"))]
+fn start_notifier_inner(_: impl AsRef<Path>) -> futures::stream::Pending<NotifierEvent> {
+    panic!()
+}
+
+/// Returns true if the given file content can potentially be a Wasm file.
+///
+/// In other words: returns false if we are sure that this isn't a Wasm file, and true
+/// otherwise.
+#[cfg(feature = "notify")]
+fn can_be_wasm(path: impl AsRef<Path>, data: &[u8]) -> bool {
+    if path.as_ref().extension() != Some("wasm".as_ref()) {
+        return false;
+    }
+
+    if data.len() <= 8 {
+        return false;
+    }
+
+    if &data[0..8] != &[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00] {
+        return false;
+    }
+
+    true
+}


### PR DESCRIPTION
A few changes:

- The CLI kernel has been improved and now accepts paths to foreground modules and background modules, or hashes of foreground modules and background modules. When a hash is passed, it is loaded from the peer-to-peer network.

- The passive node will now watch files in the `../target/wasm32-wasi/release` directory for Wasm files and automatically push them on the DHT.

It works in the sense that small files do work, but large files don't get through to the bootstrap node because of the size limit. Libp2p-kad unfortunately doesn't let you configure the maximum message size at the moment.
