### PR TITLE
Remove PlatformSpecific::block_on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2020-03-12
+        toolchain: nightly-2020-03-22
         target: wasm32-wasi
         override: true
     - name: Install a recent version of clang
@@ -147,7 +147,7 @@ jobs:
     - name: Install nightly Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2020-03-12
+        toolchain: nightly-2020-03-22
         target: wasm32-wasi
         override: true
     - name: Install rust-src

--- a/core/src/extrinsics/wasi.rs
+++ b/core/src/extrinsics/wasi.rs
@@ -79,13 +79,12 @@ impl Default for WasiExtrinsics {
         let fs_root = Arc::new(Inode::Directory {
             entries: Mutex::new({
                 let mut hashmap = HashMap::default();
-                // TODO: hack to toy with DOOM
-                /*hashmap.insert(
+                hashmap.insert(
                     "doom1.wad".to_string(),
                     Arc::new(Inode::File {
                         content: include_bytes!("../../../../DOOM/doom1.wad").to_vec(),
                     }),
-                );*/
+                );
                 hashmap
             }),
         });

--- a/core/src/extrinsics/wasi.rs
+++ b/core/src/extrinsics/wasi.rs
@@ -79,12 +79,13 @@ impl Default for WasiExtrinsics {
         let fs_root = Arc::new(Inode::Directory {
             entries: Mutex::new({
                 let mut hashmap = HashMap::default();
-                hashmap.insert(
+                // TODO: hack to toy with DOOM
+                /*hashmap.insert(
                     "doom1.wad".to_string(),
                     Arc::new(Inode::File {
                         content: include_bytes!("../../../../DOOM/doom1.wad").to_vec(),
                     }),
-                );
+                );*/
                 hashmap
             }),
         });

--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -43,9 +43,6 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// Returns the number of CPUs available.
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32;
 
-    /// Blocks the current core until the given `Future` produces a value.
-    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet;
-
     /// Returns the number of nanoseconds that happened since an undeterminate moment in time.
     ///
     /// > **Note**: The returned value is provided on a "best effort" basis and is not

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -124,7 +124,7 @@ fn cpu_enter() -> ! {
     let time = unsafe { time::TimeControl::init() };
 
     let kernel = crate::kernel::Kernel::init(PlatformSpecificImpl { time });
-    kernel.run()
+    executor::block_on(kernel.run())
 }
 
 /// Implementation of [`PlatformSpecific`].
@@ -137,10 +137,6 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         NonZeroU32::new(1).unwrap()
-    }
-
-    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet {
-        executor::block_on(future)
     }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -148,7 +148,7 @@ unsafe extern "C" fn after_boot(multiboot_header: usize) -> ! {
                 move || {
                     let kernel = executor.block_on(kernel_rx).unwrap();
                     // The `run()` method never returns.
-                    kernel.run()
+                    executor.block_on(kernel.run())
                 }
             },
         );
@@ -182,7 +182,7 @@ unsafe extern "C" fn after_boot(multiboot_header: usize) -> ! {
 
     // Start the kernel on the boot processor too.
     // This function never returns.
-    kernel.run()
+    executor.block_on(kernel.run())
 }
 
 /// Reads the boot information and find the memory ranges that can be used as a heap.
@@ -273,10 +273,6 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         self.num_cpus
-    }
-
-    fn block_on<TRet>(self: Pin<&Self>, future: impl Future<Output = TRet>) -> TRet {
-        self.executor.block_on(future)
     }
 
     fn monotonic_clock(self: Pin<&Self>) -> u128 {

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -49,12 +49,12 @@ where
     }
 
     /// Run the kernel. Must be called once per CPU.
-    pub fn run(&self) -> ! {
+    pub async fn run(&self) -> ! {
         // We only want a single CPU to run for now.
         if self.running.swap(true, Ordering::SeqCst) {
-            self.platform_specific
-                .as_ref()
-                .block_on(futures::future::pending::<()>());
+            loop {
+                futures::future::poll_fn(|_| core::task::Poll::Pending).await
+            }
         }
 
         let mut system_builder = redshirt_core::system::SystemBuilder::new()
@@ -94,9 +94,7 @@ where
             .expect("Failed to start kernel");
 
         loop {
-            // TODO: ideally the entire function would be async, and this would be an `await`,
-            // but async functions don't work on no_std yet
-            match self.platform_specific.as_ref().block_on(system.run()) {
+            match system.run().await {
                 redshirt_core::system::SystemRunOutcome::ProgramFinished { pid, outcome } => {
                     //console.write(&format!("Program finished {:?} => {:?}\n", pid, outcome));
                 }


### PR DESCRIPTION
This is mostly a celebration PR for async functions being able to work in `no_std` contexts :tada: 