### PR TITLE
Make WASI handlers more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "redshirt-log-interface",
  "redshirt-random-interface",
  "redshirt-syscalls",
+ "redshirt-system-time-interface",
  "redshirt-time-interface",
  "smallvec",
  "spin",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,7 @@ redshirt-loader-interface = { path = "../interfaces/loader", default-features = 
 redshirt-log-interface = { path = "../interfaces/log", default-features = false }
 redshirt-random-interface = { path = "../interfaces/random", default-features = false }
 redshirt-syscalls = { path = "../interfaces/syscalls", default-features = false }
+redshirt-system-time-interface = { path = "../interfaces/system-time", default-features = false }
 redshirt-time-interface = { path = "../interfaces/time", default-features = false }
 rand = { version = "0.7", default-features = false }
 rand_chacha = { version = "0.2.1", default-features = false }


### PR DESCRIPTION
- The `clock_time_get` function now properly uses the `system-time` interface for the real time clock.
- Turns a lot of panics into regular errors that will trigger a `ProgramCrash`.
