### PR TITLE
Add some options to GRUB

### DIFF
--- a/kernel/standalone-builder/src/image.rs
+++ b/kernel/standalone-builder/src/image.rs
@@ -148,8 +148,11 @@ fn build_x86_multiboot2_cdrom_iso(
         &br#"
 set timeout=5
 set default=0
+set gfxmode=auto
+set gfxpayload=auto
 
 menuentry "redshirt" {
+    insmod all_video
     multiboot2 /boot/kernel
 }
             "#[..],


### PR DESCRIPTION
Makes GRUB not show a warning about being unable to load graphics mode.