### PR TITLE
Properly implement paging

### DIFF
--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -33,6 +33,7 @@ mod apic;
 mod boot;
 mod executor;
 mod interrupts;
+mod paging;
 mod panic;
 mod pit;
 
@@ -84,6 +85,8 @@ unsafe extern "C" fn after_boot(multiboot_info: usize) -> ! {
             None => panic!("Couldn't find free memory range for the AP allocator"),
         }
     };
+
+    let _paging = paging::load_identity_mapping();
 
     // Now that we have a memory allocator, initialize the logging system .
     let logger = Arc::new(KLogger::new({

--- a/kernel/standalone/src/arch/x86_64/paging.rs
+++ b/kernel/standalone/src/arch/x86_64/paging.rs
@@ -1,0 +1,95 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+use raw_table::RawPageTable;
+
+mod cr3;
+mod entry;
+mod raw_table;
+
+pub unsafe fn load_identity_mapping() -> Paging {
+    let mut pds = Vec::with_capacity(32);
+
+    let mut pdpt = RawPageTable::new();
+    for n in 0..32 {
+        let pd = RawPageTable::new();
+        pdpt[n] = TryFrom::try_from(entry::DecodedPml4ePdptePde {
+            present: true,
+            read_write: true,
+            user: false,
+            write_through: false,
+            cache_disable: false,
+            accessed: false,
+            physical_address: pd.address(),
+            execute_disable: false,
+        })
+        .unwrap();
+        pds.push(pd);
+    }
+
+    for (one_gb, pd) in pds.iter_mut().enumerate() {
+        for n in 0..512 {
+            pd[n] = TryFrom::try_from(entry::DecodedPde2M {
+                present: true,
+                read_write: true,
+                user: false,
+                write_through: false,
+                cache_disable: false,
+                accessed: false,
+                dirty: false,
+                global: false,
+                attributes_table: false,
+                physical_address: one_gb * 1024 * 1024 * 1024 + n * 2 * 1024 * 1024,
+                execute_disable: false,
+                protection_key: 0,
+            })
+            .unwrap();
+        }
+    }
+
+    let mut pml4 = RawPageTable::new();
+    pml4[0] = TryFrom::try_from(entry::DecodedPml4ePdptePde {
+        present: true,
+        read_write: true,
+        user: false,
+        write_through: false,
+        cache_disable: false,
+        accessed: false,
+        physical_address: pdpt.address(),
+        execute_disable: false,
+    })
+    .unwrap();
+
+    cr3::load_cr3(&pml4, false, false);
+
+    Paging { pml4, pdpt, pds }
+}
+
+pub struct Paging {
+    pml4: raw_table::RawPageTable,
+    pdpt: raw_table::RawPageTable,
+    pds: Vec<raw_table::RawPageTable>,
+}
+
+impl Paging {}
+
+impl Drop for Paging {
+    fn drop(&mut self) {
+        // TODO: explain
+        panic!();
+    }
+}

--- a/kernel/standalone/src/arch/x86_64/paging/cr3.rs
+++ b/kernel/standalone/src/arch/x86_64/paging/cr3.rs
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::raw_table::RawPageTable;
+
+/// Loads the given page tables as the current PML4.
+///
+/// # Safety
+///
+/// The entries in the table must be valid and must remain valid if they get modified.
+/// The table must not be destroyed. None of the other tables it references must be destroyed.
+// TODO: explain flags
+pub unsafe fn load_cr3(pml4: &RawPageTable, write_through: bool, cache_disable: bool) {
+    debug_assert_eq!(pml4.address() % 4 * 1024, 0);
+
+    let value = pml4.address()
+        | (if write_through { 1 } else { 0 } << 3)
+        | (if cache_disable { 1 } else { 0 } << 4);
+    asm!("mov $0, %cr3" :: "r"(value) : "memory" : "volatile");
+}

--- a/kernel/standalone/src/arch/x86_64/paging/entry.rs
+++ b/kernel/standalone/src/arch/x86_64/paging/entry.rs
@@ -1,0 +1,220 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use core::convert::TryFrom;
+
+/// Represents a PML4E, PDPTE, PDE, or PTE. In other words, an entry in a table used in the
+/// paging system.
+#[derive(Debug, Copy, Clone)] // TODO: better Debug impl
+#[repr(transparent)]
+pub struct EncodedEntry(usize);
+
+impl EncodedEntry {
+    pub fn raw_value(&self) -> usize {
+        self.0
+    }
+}
+
+// TODO: impl Display
+#[derive(Debug)]
+pub enum DecodeError {
+    InvalidTy,
+}
+
+/// Represents an absent entry.
+///
+/// Can be turned into an [`EncodedEntry`] with the `From` trait.
+pub struct Absent;
+
+impl From<Absent> for EncodedEntry {
+    fn from(_: Absent) -> EncodedEntry {
+        EncodedEntry(0)
+    }
+}
+
+impl TryFrom<EncodedEntry> for Absent {
+    type Error = DecodeError;
+    fn try_from(value: EncodedEntry) -> Result<Self, Self::Error> {
+        if value.0 & 0x1 == 0 {
+            Ok(Absent)
+        } else {
+            Err(DecodeError::InvalidTy)
+        }
+    }
+}
+
+pub struct DecodedPml4ePdptePde {
+    pub present: bool,
+    pub read_write: bool,
+    pub user: bool,
+    pub write_through: bool,
+    pub cache_disable: bool,
+    pub accessed: bool,
+    pub physical_address: usize,
+    pub execute_disable: bool,
+}
+
+impl TryFrom<DecodedPml4ePdptePde> for EncodedEntry {
+    type Error = ();
+    fn try_from(decoded: DecodedPml4ePdptePde) -> Result<Self, Self::Error> {
+        TryFrom::try_from(DecodedAll {
+            present: decoded.present,
+            read_write: decoded.read_write,
+            user: decoded.user,
+            write_through: decoded.write_through,
+            cache_disable: decoded.cache_disable,
+            accessed: decoded.accessed,
+            dirty: false,
+            bit7: false,
+            global: false,
+            bit12: false,
+            physical_address: decoded.physical_address,
+            protection_key: 0,
+            execute_disable: decoded.execute_disable,
+        })
+    }
+}
+
+pub struct DecodedPdpte1G {
+    pub present: bool,
+    pub read_write: bool,
+    pub user: bool,
+    pub write_through: bool,
+    pub cache_disable: bool,
+    pub accessed: bool,
+    pub dirty: bool,
+    pub global: bool,
+    pub attributes_table: bool,
+    pub physical_address: usize,
+    pub protection_key: u8,
+    pub execute_disable: bool,
+}
+
+impl TryFrom<DecodedPdpte1G> for EncodedEntry {
+    type Error = ();
+    fn try_from(decoded: DecodedPdpte1G) -> Result<Self, Self::Error> {
+        if decoded.physical_address % (1024 * 1024 * 1024) != 0 {
+            return Err(());
+        }
+
+        TryFrom::try_from(DecodedAll {
+            present: decoded.present,
+            read_write: decoded.read_write,
+            user: decoded.user,
+            write_through: decoded.write_through,
+            cache_disable: decoded.cache_disable,
+            accessed: decoded.accessed,
+            dirty: decoded.dirty,
+            bit7: true,
+            global: decoded.global,
+            bit12: decoded.attributes_table,
+            physical_address: decoded.physical_address,
+            protection_key: decoded.protection_key,
+            execute_disable: decoded.execute_disable,
+        })
+    }
+}
+
+pub struct DecodedPde2M {
+    pub present: bool,
+    pub read_write: bool,
+    pub user: bool,
+    pub write_through: bool,
+    pub cache_disable: bool,
+    pub accessed: bool,
+    pub dirty: bool,
+    pub global: bool,
+    pub attributes_table: bool,
+    pub physical_address: usize,
+    pub protection_key: u8,
+    pub execute_disable: bool,
+}
+
+impl TryFrom<DecodedPde2M> for EncodedEntry {
+    type Error = ();
+    fn try_from(decoded: DecodedPde2M) -> Result<Self, Self::Error> {
+        if decoded.physical_address % (2 * 1024 * 1024) != 0 {
+            return Err(());
+        }
+
+        TryFrom::try_from(DecodedAll {
+            present: decoded.present,
+            read_write: decoded.read_write,
+            user: decoded.user,
+            write_through: decoded.write_through,
+            cache_disable: decoded.cache_disable,
+            accessed: decoded.accessed,
+            dirty: decoded.dirty,
+            bit7: true,
+            global: decoded.global,
+            bit12: decoded.attributes_table,
+            physical_address: decoded.physical_address,
+            protection_key: decoded.protection_key,
+            execute_disable: decoded.execute_disable,
+        })
+    }
+}
+
+/// Intermediary type common to all types of entries.
+struct DecodedAll {
+    present: bool,
+    read_write: bool,
+    user: bool,
+    write_through: bool,
+    cache_disable: bool,
+    accessed: bool,
+    dirty: bool,
+    bit7: bool,
+    global: bool,
+    bit12: bool,
+    physical_address: usize,
+    protection_key: u8,
+    execute_disable: bool,
+}
+
+// TODO: implement From<EncodedEntry> for DecodedAll
+
+impl TryFrom<DecodedAll> for EncodedEntry {
+    type Error = ();
+    fn try_from(decoded: DecodedAll) -> Result<Self, Self::Error> {
+        // TODO: support 32bits as well
+        // TODO: check physical_address against MAXPHYSADDR
+        if decoded.physical_address % 0x1000 != 0 {
+            return Err(());
+        }
+        if decoded.bit12 && (decoded.physical_address % 0x2000) != 0 {
+            return Err(());
+        }
+        if decoded.protection_key >= 0x10 {
+            return Err(());
+        }
+
+        let value = (if decoded.present { 1 } else { 0 } << 0)
+            | (if decoded.read_write { 1 } else { 0 } << 1)
+            | (if decoded.user { 1 } else { 0 } << 2)
+            | (if decoded.write_through { 1 } else { 0 } << 3)
+            | (if decoded.cache_disable { 1 } else { 0 } << 4)
+            | (if decoded.accessed { 1 } else { 0 } << 5)
+            | (if decoded.dirty { 1 } else { 0 } << 6)
+            | (if decoded.bit7 { 1 } else { 0 } << 7)
+            | (if decoded.global { 1 } else { 0 } << 8)
+            | (if decoded.bit12 { 1 } else { 0 } << 12)
+            | decoded.physical_address
+            | (usize::from(decoded.protection_key) << 59)
+            | (if decoded.execute_disable { 1 } else { 0 } << 63);
+
+        Ok(EncodedEntry(value))
+    }
+}

--- a/kernel/standalone/src/arch/x86_64/paging/raw_table.rs
+++ b/kernel/standalone/src/arch/x86_64/paging/raw_table.rs
@@ -1,0 +1,90 @@
+// Copyright (C) 2019-2020  Pierre Krieger
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::entry::EncodedEntry;
+use core::{
+    fmt,
+    ops::{Index, IndexMut},
+};
+
+#[cfg(target_arch = "x86_64")]
+const ENTRIES_PER_TABLE: usize = 512;
+#[cfg(target_arch = "x86")]
+const ENTRIES_PER_TABLE: usize = 1024;
+const LAYOUT: alloc::alloc::Layout =
+    unsafe { alloc::alloc::Layout::from_size_align_unchecked(4096, 4096) };
+
+/// Represents a PML4, PDPT, PD or PT. In other words, a table used in the paging system.
+///
+/// Note that this API is entirely safe despite the fact that we modify the memory's layout,
+/// which is an extremely unsafe thing to do. The safety is covered when loading a table into
+/// the CR3 register.
+pub struct RawPageTable {
+    /// Because we have some alignment constraints, we need to allocate manually.
+    table: *mut usize,
+}
+
+impl RawPageTable {
+    /// Allocates a new table. The table is zeroed out.
+    pub fn new() -> RawPageTable {
+        unsafe {
+            let ptr = alloc::alloc::alloc_zeroed(LAYOUT);
+            assert!(!ptr.is_null());
+            RawPageTable {
+                table: ptr as *mut _,
+            }
+        }
+    }
+
+    /// Returns the address of the table in memory. Guaranteed to never change and to be a
+    /// multiple of 4096.
+    pub fn address(&self) -> usize {
+        self.table as usize
+    }
+}
+
+impl fmt::Debug for RawPageTable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "RawPageTable(0x{:x})", self.address())
+    }
+}
+
+impl Drop for RawPageTable {
+    fn drop(&mut self) {
+        unsafe {
+            alloc::alloc::dealloc(self.table as *mut u8, LAYOUT);
+        }
+    }
+}
+
+impl Index<usize> for RawPageTable {
+    type Output = EncodedEntry;
+
+    fn index(&self, idx: usize) -> &EncodedEntry {
+        unsafe {
+            assert!(idx < ENTRIES_PER_TABLE);
+            &*(self.table.add(idx) as *mut EncodedEntry)
+        }
+    }
+}
+
+impl IndexMut<usize> for RawPageTable {
+    fn index_mut(&mut self, idx: usize) -> &mut EncodedEntry {
+        unsafe {
+            assert!(idx < ENTRIES_PER_TABLE);
+            &mut *(self.table.add(idx) as *mut EncodedEntry)
+        }
+    }
+}


### PR DESCRIPTION
cc #73 #379 

Despite identity-mapping everything, we still need to properly handle paging in order for the CPU to disable caches for any memory-mapped register and in order to detect stack overflows.
