### PR TITLE
Fix two bugs related to notifications delivery

### DIFF
--- a/core/src/scheduler/extrinsics/calls.rs
+++ b/core/src/scheduler/extrinsics/calls.rs
@@ -18,7 +18,7 @@
 use crate::scheduler::processes;
 use crate::{InterfaceHash, MessageId};
 
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::{convert::TryFrom as _, num::NonZeroU64};
 use redshirt_syscalls::EncodedMessage;
 
@@ -62,9 +62,7 @@ pub fn parse_extrinsic_next_notification<TExtr, TPud, TTud>(
         let mut out = Vec::with_capacity(len_usize);
         for i in mem.chunks(8) {
             let id = u64::from_le_bytes(<[u8; 8]>::try_from(i).unwrap());
-            if let Some(id) = NonZeroU64::new(id) {
-                out.push(MessageId::from(id));
-            }
+            out.push(NonZeroU64::new(id).map(MessageId::from));
         }
         out
     };
@@ -100,7 +98,8 @@ pub fn parse_extrinsic_next_notification<TExtr, TPud, TTud>(
 pub struct NotificationWait {
     /// Identifiers of the notifications the process is waiting upon. Copy of what is in the
     /// process's memory.
-    pub notifs_ids: Vec<MessageId>,
+    // TODO: better typing; this can contain `1` for interfaces, which is not a message ID
+    pub notifs_ids: Vec<Option<MessageId>>,
     /// Offset within the memory of the process where the list of notifications to wait upon is
     /// located. This is required to zero that location.
     pub notifs_ids_ptr: u32,

--- a/core/src/scheduler/ipc/notifications_queue.rs
+++ b/core/src/scheduler/ipc/notifications_queue.rs
@@ -115,7 +115,7 @@ impl NotificationsQueue {
     /// If an entry is found, its corresponding index within `indices` is stored in the returned
     /// `Entry`.
     // TODO: better param type
-    pub fn find(&self, indices: &[MessageId]) -> Option<Entry> {
+    pub fn find(&self, indices: &[Option<MessageId>]) -> Option<Entry> {
         let notifications_queue = self.notifications_queue.lock();
 
         let mut index_in_queue = 0;
@@ -137,7 +137,7 @@ impl NotificationsQueue {
                 }
             };
 
-            if let Some(p) = indices.iter().position(|id| *id == msg_id) {
+            if let Some(p) = indices.iter().position(|id| *id == Some(msg_id)) {
                 break p;
             }
 

--- a/interfaces/syscalls/src/block_on.rs
+++ b/interfaces/syscalls/src/block_on.rs
@@ -148,7 +148,6 @@ pub fn block_on<T>(future: impl Future<Output = T>) -> T {
         }
 
         let mut state = (&*STATE).lock();
-        debug_assert_eq!(state.message_ids.len(), state.wakers.len());
 
         // `block` indicates whether we should block the thread or just peek. Always `true` during
         // the first iteration, and `false` in further iterations.


### PR DESCRIPTION
- That assertion in `syscalls` is wrong. The size can differ between the two lists, since we remove elements from the wakers list but only zero elements in the messages list.

- In the kernel, we would discard zero'ed entries in the messages list. This is wrong, as we have to send back to the user the position of the entry in the list. By discarding zero'ed entries, that position would be wrong.
