### PR TITLE
Ensure interrupts can't deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc655351f820d774679da6cdc23355a93de496867d8203496675162e17b1d671"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1766,7 @@ dependencies = [
  "blake3",
  "crossbeam-queue",
  "crossbeam-utils",
+ "derive_more",
  "either",
  "fnv 1.0.6",
  "futures",

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 blake3 = { version = "0.2.2", default-features = false }
 crossbeam-queue = { version = "0.2.1", default-features = false, features = ["alloc"] }
+derive_more = "0.99.8"
 either = { version = "1.5.3", default-features = false }
 fnv = { git = "https://github.com/dflemstr/rust-fnv", default-features = false }    # TODO: https://github.com/servo/rust-fnv/pull/22
 futures = { version = "0.3.2", default-features = false, features = ["alloc"] }

--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -60,6 +60,9 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// >           necessarily exact (it is, in fact, rarely exact).
     fn monotonic_clock(self: Pin<&Self>) -> u128;
     /// Returns a `Future` that fires when the monotonic clock reaches the given value.
+    ///
+    /// > **Important**: The returned future is not guaranteed to function properly with an
+    /// >                executor other than the ones in the platform-specific code.
     fn timer(self: Pin<&Self>, clock_value: u128) -> Self::TimerFuture;
 
     /// Writes a `u8` on a port. Returns an error if the operation is not supported or if the port

--- a/kernel/standalone/src/arch/x86_64/apic/local.rs
+++ b/kernel/standalone/src/arch/x86_64/apic/local.rs
@@ -59,6 +59,8 @@ pub unsafe fn init() -> LocalApicsControl {
 
 // TODO: bad API ; should be a method on LocalApisControl, and a &'static ref passed when
 // initializing the IDT
+// TODO: document that no mutex is being locked; important because it's called from within an
+// interrupt handler
 pub unsafe fn end_of_interrupt() {
     let addr = usize::try_from(APIC_BASE_ADDR + 0xB0).unwrap() as *mut u32;
     addr.write_volatile(0x0);

--- a/kernel/standalone/src/arch/x86_64/executor.rs
+++ b/kernel/standalone/src/arch/x86_64/executor.rs
@@ -69,11 +69,15 @@ impl Executor {
             }
 
             loop {
+                // As documented in the [`../interrupts`] module, we have to manually wake up the
+                // `Future`s that were waiting for an interrupt to happen.
+                interrupts::process_wakers();
+
                 debug_assert!(x86_64::instructions::interrupts::are_enabled());
                 x86_64::instructions::interrupts::disable();
 
-                // We store `true` in `need_ipi` before checking `woken_up`, otherwise there could be
-                // a state where `need_ipi` is `false` but we've already checked `woken_up`.
+                // We store `true` in `need_ipi` before checking `woken_up`, otherwise there could
+                // be a state where `need_ipi` is `false` but we've already checked `woken_up`.
                 local_wake.need_ipi.store(true, atomic::Ordering::SeqCst);
 
                 if local_wake

--- a/kernel/standalone/src/arch/x86_64/interrupts.rs
+++ b/kernel/standalone/src/arch/x86_64/interrupts.rs
@@ -17,8 +17,16 @@
 //!
 //! This module provides handling of interrupts on x86_64. It sets up the interrupts table (IDT)
 //! and allows reserving interrupt vectors. Once done, you can register a
-//! [`Waker`](core::task::Waker) that is waken up when an interrupt happens.
-//! This is done by calling [`ReservedInterruptVector::register_waker`].
+//! [`Waker`](core::task::Waker) that is waken up when an interrupt happens. This is done by
+//! calling [`ReservedInterruptVector::register_waker`].
+//!
+//! Because interrupts can happen at any time, it is important that interrupt handlers do not use
+//! any mutex whatsoever, unless interrupts are disabled before locking the mutex and re-enabled
+//! after unlocking it.
+//! Unfortunately, waking up a [`Waker`] might (and often does) lock a mutex. For this reasons,
+//! when an interrupt happens we only queue the corresponding waker, and wakers are only actually
+//! woken up when you later call [`process_wakers`].
+//! It is expected that [`process_wakers`] gets called by the tasks executor.
 //!
 //! Note that this API is racy. Once a `Waker` has been woken up, it gets discarded and needs to
 //! be registered again. It is possible that an interrupt gets triggered between the discard and
@@ -38,6 +46,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
     task::Waker,
 };
+use crossbeam_queue::ArrayQueue;
 use futures::task::AtomicWaker;
 use x86_64::structures::idt;
 
@@ -67,9 +76,19 @@ pub struct ReservedInterruptVector {
     interrupt: u8,
 }
 
-#[derive(Debug)]
+/// Error returned by [`reserve_any_vector`].
+#[derive(Debug, derive_more::Display)]
 pub enum ReserveErr {
+    /// No free interrupt vector available.
     Full,
+}
+
+/// Wake up all the wakers that have been marked as ready by all the interrupt(s) that have
+/// happened since the last call to this function.
+pub fn process_wakers() {
+    while let Ok(waker) = WAKERS_QUEUE.pop() {
+        waker.wake();
+    }
 }
 
 /// Loads the global IDT on the local processor and enables interrupts.
@@ -121,6 +140,10 @@ impl Drop for ReservedInterruptVector {
 }
 
 lazy_static::lazy_static! {
+    /// When an interrupt happens, we push the corresponding waker here. This list is emptied by
+    /// [`process_wakers`]
+    static ref WAKERS_QUEUE: ArrayQueue<Waker> = ArrayQueue::new(512);
+
     /// Table read by the hardware in order to determine what to do when an interrupt happens.
     static ref IDT: idt::InterruptDescriptorTable = {
         let mut idt = idt::InterruptDescriptorTable::new();
@@ -165,7 +188,12 @@ lazy_static::lazy_static! {
             }};
             ($entry:expr, $n:expr) => {{
                 extern "x86-interrupt" fn handler(_: &mut idt::InterruptStackFrame) {
-                    WAKERS[$n - 32].wake();
+                    // Because interrupts can happen at any time, it is important the code below
+                    // doesn't lock any mutex.
+                    if let Some(waker) = WAKERS[$n - 32].take() {
+                        // TODO: what if queue is legitimately full?
+                        WAKERS_QUEUE.push(waker).unwrap();
+                    }
                     if END_OF_INTERRUPT[$n - 32].load(Ordering::Relaxed) {
                         unsafe { local::end_of_interrupt(); }
                     }


### PR DESCRIPTION
Unfortunately we can't directly calle `Waker::wake()`, as waking might uses mutexes.