### PR TITLE
Make waiting for a PCI IRQ work

### DIFF
--- a/kernel/standalone/src/arch.rs
+++ b/kernel/standalone/src/arch.rs
@@ -41,6 +41,9 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// `Future` that fires when the monotonic clock reaches a certain value.
     // TODO: remove `'static` requirement
     type TimerFuture: Future<Output = ()> + Send + 'static;
+    /// `Future` that fires when an IRQ is triggered.
+    // TODO: remove `'static` requirement
+    type IrqFuture: Future<Output = ()> + Send + 'static;
 
     /// Returns the number of CPUs available.
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32;
@@ -64,6 +67,13 @@ pub trait PlatformSpecific: Send + Sync + 'static {
     /// > **Important**: The returned future is not guaranteed to function properly with an
     /// >                executor other than the ones in the platform-specific code.
     fn timer(self: Pin<&Self>, clock_value: u128) -> Self::TimerFuture;
+
+    /// Returns a `Future` that fires the next time the given IRQ is triggered.
+    ///
+    /// > **Important**: The returned future is not guaranteed to function properly with an
+    /// >                executor other than the ones in the platform-specific code.
+    // TODO: pass some IRQ number and define what this number exactly means
+    fn next_irq(self: Pin<&Self>) -> Self::IrqFuture;
 
     /// Writes a `u8` on a port. Returns an error if the operation is not supported or if the port
     /// is out of range.

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -141,6 +141,7 @@ struct PlatformSpecificImpl {
 
 impl PlatformSpecific for PlatformSpecificImpl {
     type TimerFuture = time::TimerFuture;
+    type IrqFuture = future::Pending<()>;
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         NonZeroU32::new(1).unwrap()
@@ -152,6 +153,10 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn timer(self: Pin<&Self>, deadline: u128) -> Self::TimerFuture {
         self.time.timer(deadline)
+    }
+
+    fn next_irq(self: Pin<&Self>) -> Self::IrqFuture {
+        future::pending()
     }
 
     fn write_log(&self, message: &str) {

--- a/kernel/standalone/src/arch/riscv.rs
+++ b/kernel/standalone/src/arch/riscv.rs
@@ -159,6 +159,7 @@ struct PlatformSpecificImpl {}
 
 impl PlatformSpecific for PlatformSpecificImpl {
     type TimerFuture = future::Pending<()>;
+    type IrqFuture = future::Pending<()>;
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         // TODO:
@@ -204,6 +205,10 @@ impl PlatformSpecific for PlatformSpecificImpl {
 
     fn timer(self: Pin<&Self>, deadline: u128) -> Self::TimerFuture {
         unimplemented!()
+    }
+
+    fn next_irq(self: Pin<&Self>) -> Self::IrqFuture {
+        future::pending()
     }
 
     fn write_log(&self, message: &str) {

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -544,7 +544,11 @@ impl Future for NextIrqFuture {
         {
             let mut next_irq_futures = self.next_irq_futures.lock();
             match next_irq_futures.entry(self.id) {
-                Entry::Occupied(mut e) => e.get_mut().1 = cx.waker().clone(), // TODO: compare waker before cloning
+                Entry::Occupied(mut e) => {
+                    if !e.get().1.will_wake(cx.waker()) {
+                        e.get_mut().1 = cx.waker().clone();
+                    }
+                }
                 Entry::Vacant(e) => {
                     e.insert((self.done.clone(), cx.waker().clone()));
                 }

--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -20,11 +20,21 @@ use crate::klog::KLogger;
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::{
-    convert::TryFrom as _, fmt::Write as _, iter, num::NonZeroU32, ops::Range, pin::Pin,
+    convert::TryFrom as _,
+    fmt::Write as _,
+    future::Future,
+    iter,
+    num::NonZeroU32,
+    ops::Range,
+    pin::Pin,
+    sync::atomic,
+    task::{Context, Poll, Waker},
     time::Duration,
 };
 use futures::channel::oneshot;
+use hashbrown::{hash_map::Entry, HashMap};
 use redshirt_kernel_log_interface::ffi::{FramebufferFormat, FramebufferInfo, KernelLogMethod};
+use spinning_top::Spinlock;
 use x86_64::structures::port::{PortRead as _, PortWrite as _};
 
 mod acpi;
@@ -175,7 +185,26 @@ unsafe extern "C" fn after_boot(multiboot_info: usize) -> ! {
     // This allows us to create `Future`s that resolve after a certain amount of time has passed.
     let timers = executor.block_on(apic::timers::init(local_apics, &mut pit));
 
-    // This code is only executed by the main processor of the machine, called the **boot
+    // We no longer need the `pit`. Since we overwrite all the IRQs below, and the PIT uses an IRQ,
+    // the PIT will stop working. We destroy it to make sure that we're not going to attempt to
+    // use it.
+    // TODO: add some safety mechanism regarding overwriting IRQs? ^
+    drop(pit);
+
+    // Considering that it is quite complicated to determine which IRQ a PCI device is going to
+    // use (it requires parsing and executing AML tables), we instead go with the strategy of
+    // redirecting all IRQs to a single interrupt vector. This single interrupt vector, when
+    // triggered, notifies all the components that were waiting for a PCI interrupt.
+    // TODO: make this better ^
+    let pci_interrupt_vector = interrupts::reserve_any_vector(true).unwrap();
+    for irq in io_apics.irqs().collect::<Vec<_>>() {
+        io_apics.irq(irq).unwrap().set_destination(
+            local_apics.current_apic_id(),
+            pci_interrupt_vector.interrupt_num(),
+        );
+    }
+
+    // This function is only executed by the main processor of the machine, called the **boot
     // processor**. The other processors are called the **associated processors** and must be
     // manually started.
 
@@ -226,6 +255,41 @@ unsafe extern "C" fn after_boot(multiboot_info: usize) -> ! {
     // Now that everything has been initialized and all the processors started, we can initialize
     // the kernel.
     let kernel = {
+        /// Waker registered for `pci_interrupt_vector`. Re-registers itself automatically
+        /// whenever it is woken up.
+        struct NextIrqWaker {
+            pci_interrupt_vector: interrupts::ReservedInterruptVector,
+            next_irq_futures:
+                Arc<Spinlock<HashMap<u64, (Arc<atomic::AtomicBool>, Waker), fnv::FnvBuildHasher>>>,
+        }
+
+        impl futures::task::ArcWake for NextIrqWaker {
+            fn wake_by_ref(arc_self: &Arc<Self>) {
+                let mut next_irq_futures = arc_self.next_irq_futures.lock();
+
+                // Re-register ourselves for the next time.
+                arc_self
+                    .pci_interrupt_vector
+                    .register_waker(&futures::task::waker_ref(arc_self));
+
+                for (_, (atomic_bool, waker)) in next_irq_futures.drain() {
+                    atomic_bool.store(true, atomic::Ordering::Acquire);
+                    waker.wake();
+                }
+            }
+        }
+
+        let next_irq_futures = Arc::new(Spinlock::new(Default::default()));
+
+        let waker = Arc::new(NextIrqWaker {
+            pci_interrupt_vector,
+            next_irq_futures: next_irq_futures.clone(),
+        });
+
+        waker
+            .pci_interrupt_vector
+            .register_waker(&futures::task::waker(waker.clone()));
+
         let platform_specific = PlatformSpecificImpl {
             timers,
             num_cpus: NonZeroU32::new(
@@ -236,6 +300,8 @@ unsafe extern "C" fn after_boot(multiboot_info: usize) -> ! {
             )
             .unwrap(),
             logger: logger.clone(),
+            next_irq_futures,
+            next_next_irq_id: From::from(0),
         };
 
         Arc::new(crate::kernel::Kernel::init(platform_specific))
@@ -360,10 +426,17 @@ struct PlatformSpecificImpl {
     timers: Arc<apic::timers::Timers>,
     num_cpus: NonZeroU32,
     logger: Arc<KLogger>,
+
+    next_next_irq_id: atomic::AtomicU64,
+    /// List of active futures waiting for the next IRQ.
+    /// Contains an `AtomicBool` to set to true when the IRQ happens, and the waker to wake up.
+    next_irq_futures:
+        Arc<Spinlock<HashMap<u64, (Arc<atomic::AtomicBool>, Waker), fnv::FnvBuildHasher>>>,
 }
 
 impl PlatformSpecific for PlatformSpecificImpl {
     type TimerFuture = apic::timers::TimerFuture;
+    type IrqFuture = NextIrqFuture;
 
     fn num_cpus(self: Pin<&Self>) -> NonZeroU32 {
         self.num_cpus
@@ -379,6 +452,18 @@ impl PlatformSpecific for PlatformSpecificImpl {
             let nanos = u32::try_from(clock_value % 1_000_000_000).unwrap();
             Duration::new(secs, nanos)
         })
+    }
+
+    fn next_irq(self: Pin<&Self>) -> Self::IrqFuture {
+        let done = Arc::new(atomic::AtomicBool::new(false));
+
+        NextIrqFuture {
+            next_irq_futures: self.next_irq_futures.clone(),
+            done,
+            id: self
+                .next_next_irq_id
+                .fetch_add(1, atomic::Ordering::Relaxed),
+        }
     }
 
     fn write_log(&self, message: &str) {
@@ -438,5 +523,45 @@ impl PlatformSpecific for PlatformSpecificImpl {
         } else {
             Err(PortErr::OutOfRange)
         }
+    }
+}
+
+struct NextIrqFuture {
+    next_irq_futures:
+        Arc<Spinlock<HashMap<u64, (Arc<atomic::AtomicBool>, Waker), fnv::FnvBuildHasher>>>,
+    done: Arc<atomic::AtomicBool>,
+    id: u64,
+}
+
+impl Future for NextIrqFuture {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<()> {
+        if self.done.load(atomic::Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
+
+        {
+            let mut next_irq_futures = self.next_irq_futures.lock();
+            match next_irq_futures.entry(self.id) {
+                Entry::Occupied(mut e) => e.get_mut().1 = cx.waker().clone(), // TODO: compare waker before cloning
+                Entry::Vacant(e) => {
+                    e.insert((self.done.clone(), cx.waker().clone()));
+                }
+            }
+        }
+
+        if self.done.load(atomic::Ordering::SeqCst) {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for NextIrqFuture {
+    fn drop(&mut self) {
+        let mut next_irq_futures = self.next_irq_futures.lock();
+        let _ = next_irq_futures.remove(&self.id);
     }
 }

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -47,6 +47,8 @@ where
     /// Initializes a new `Kernel`.
     pub fn init(platform_specific: TPlat) -> Self {
         let platform_specific = Arc::pin(platform_specific);
+
+        // TODO: don't do this on platforms that don't have PCI?
         let pci_devices = unsafe { crate::pci::pci::init_cam_pci() };
 
         let mut system_builder = redshirt_core::system::SystemBuilder::new()
@@ -57,7 +59,10 @@ where
             .with_native_program(crate::random::native::RandomNativeProgram::new(
                 platform_specific.clone(),
             ))
-            .with_native_program(crate::pci::native::PciNativeProgram::new(pci_devices))
+            .with_native_program(crate::pci::native::PciNativeProgram::new(
+                pci_devices,
+                platform_specific.clone(),
+            ))
             .with_native_program(crate::klog::KernelLogNativeProgram::new(
                 platform_specific.clone(),
             ))

--- a/kernel/standalone/src/pci/native.rs
+++ b/kernel/standalone/src/pci/native.rs
@@ -31,6 +31,9 @@ use spinning_top::Spinlock;
 pub struct PciNativeProgram<TPlat> {
     /// Platform-specific hooks.
     platform_specific: Pin<Arc<TPlat>>,
+    /// Future triggered the next time a PCI device generates an interrupt.
+    // TODO: at the moment we don't differentiate between devices
+    next_irq: Spinlock<Pin<Box<dyn Future<Output = ()> + Send>>>,
 
     /// Devices manager. Does the actual work.
     devices: pci::PciDevices,
@@ -59,8 +62,12 @@ where
 {
     /// Initializes the new state machine for PCI messages handling.
     pub fn new(devices: pci::PciDevices, platform_specific: Pin<Arc<TPlat>>) -> Self {
+        let next_irq =
+            Spinlock::new(Box::pin(TPlat::next_irq(platform_specific.as_ref())) as Pin<Box<_>>);
+
         PciNativeProgram {
             platform_specific,
+            next_irq,
             devices,
             locked_devices: Spinlock::new(Vec::new()),
             registered: atomic::AtomicBool::new(false),
@@ -96,7 +103,35 @@ where
                 answer,
             }))
         } else {
-            Box::pin(future::pending())
+            let next_irq = &self.next_irq;
+            let locked_devices = &self.locked_devices;
+            let platform_specific = &self.platform_specific;
+
+            Box::pin(async move {
+                loop {
+                    if let Ok((message_id, answer)) = self.pending_messages.pop() {
+                        return NativeProgramEvent::Answer { message_id, answer };
+                    }
+
+                    // Wait for next IRQ.
+                    future::poll_fn(move |cx| Future::poll(Pin::new(&mut *next_irq.lock()), cx))
+                        .await;
+
+                    let mut locked_devices = locked_devices.lock();
+                    for device in locked_devices.iter_mut() {
+                        for msg in device.next_interrupt_messages.drain(..) {
+                            let answer =
+                                redshirt_pci_interface::ffi::NextInterruptResponse::Interrupt
+                                    .encode();
+                            self.pending_messages.push((msg, Ok(answer)));
+                        }
+                    }
+                    drop(locked_devices);
+
+                    *next_irq.lock() =
+                        Box::pin(TPlat::next_irq(platform_specific.as_ref())) as Pin<Box<_>>;
+                }
+            })
         }
     }
 


### PR DESCRIPTION
The PCI interface makes it possible to get notified when the PCI device generates an interrupt, but this was previously implemented as a stub. This PR properly implements this.

Note that the implementation isn't very clean, as *all* IRQs will wake up *all* PCI devices drivers. But at least it will work.
Implementing it properly would require analyzing and executing the AML tables, which is notoriously painful.
