### PR TITLE
Make standalone kernel multithreaded

### DIFF
--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -34,8 +34,6 @@ use redshirt_core::{build_wasm_module, System};
 /// Main struct of this crate. Runs everything.
 pub struct Kernel<TPlat> {
     system: System<'static>,
-    /// If true, the kernel has started running from a different thread already.
-    running: AtomicBool,
     /// Phantom data so that we can keep the platform specific generic parameter.
     marker: PhantomData<TPlat>,
 }
@@ -88,20 +86,12 @@ where
 
         Kernel {
             system: system_builder.build().expect("failed to start kernel"),
-            running: AtomicBool::new(false),
             marker: PhantomData,
         }
     }
 
     /// Run the kernel. Must be called once per CPU.
     pub async fn run(&self) -> ! {
-        // TODO: we only run on a single CPU for now, to be cautious
-        if self.running.swap(true, Ordering::SeqCst) {
-            loop {
-                futures::future::poll_fn(|_| core::task::Poll::Pending).await
-            }
-        }
-
         loop {
             match self.system.run().await {
                 redshirt_core::system::SystemRunOutcome::ProgramFinished { .. } => {}


### PR DESCRIPTION
I don't remember why this wasn't already the case, but here's a PR that enables running the kernel from multiple CPUs simultaneously.

Apart from the simple bugfix in `NextIrqFuture`, everything seems to work flawlessly.