### PR TITLE
Remove deps.rs badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ network.
 
 See the `docs/introduction.md` file for an introduction.
 
-[![dependency status](https://deps.rs/repo/github/tomaka/os/status.svg)](https://deps.rs/repo/github/tomaka/os)
-
 # How to test
 
 **Important**: At the moment, most of the compilation requires a nightly version of Rust. See also https://github.com/tomaka/redshirt/issues/300.


### PR DESCRIPTION
The service has been dead for some time now, and the chances of it working again soon look slim.
https://github.com/srijs/deps.rs/issues/41

We can always restore the badge when it works again.
