### PR TITLE
Improvements to p2p-loader

### DIFF
--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -29,7 +29,7 @@ use core::{
     marker::PhantomData,
     sync::atomic::{AtomicBool, Ordering},
 };
-use redshirt_core::{build_wasm_module, System};
+use redshirt_core::{build_wasm_module, module::ModuleHash, System};
 
 /// Main struct of this crate. Runs everything.
 pub struct Kernel<TPlat> {
@@ -66,7 +66,7 @@ where
             ))
             .with_startup_process(build_wasm_module!(
                 "../../../modules/p2p-loader",
-                "passive-node"
+                "modules-loader"
             ))
             .with_startup_process(build_wasm_module!("../../../modules/pci-printer"))
             .with_startup_process(build_wasm_module!("../../../modules/log-to-kernel"))
@@ -85,6 +85,11 @@ where
             system_builder = system_builder
                 .with_startup_process(build_wasm_module!("../../../modules/rpi-framebuffer"))
         }
+
+        // TODO: temporary; uncomment to test
+        /*system_builder = system_builder.with_main_program(
+            ModuleHash::from_base58("FWMwRMQCKdWVDdKyx6ogQ8sXuoeDLNzZxniRMyD5S71").unwrap(),
+        );*/
 
         Kernel {
             system: system_builder.build().expect("failed to start kernel"),

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -199,8 +199,9 @@ impl<T> Network<T> {
             "/ip4/157.245.20.120/tcp/30333".parse().unwrap(),
         );
 
-        // Bootstrapping returns an error if we don't know of any peer.
-        swarm.bootstrap().unwrap();
+        // Bootstrapping returns an error if we don't know of any other peer to connect to.
+        // This would typically happen on the bootnode itself.
+        let _ = swarm.bootstrap();
 
         Ok(Network {
             swarm,

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -193,7 +193,7 @@ impl<T> Network<T> {
 
         // Bootnode.
         swarm.add_address(
-            &"Qmc25MQxSxbUpU49bZ7RVEqgBJPB3SrjG8WVycU3KC7xYP"
+            &"12D3KooWCWX1zQ3WXSMGuDK2qgVPgC4itYUkj84AsxBYcafMX6ot"
                 .parse()
                 .unwrap(),
             "/ip4/157.245.20.120/tcp/30333".parse().unwrap(),


### PR DESCRIPTION
- Now properly use the modules loader on the standalone kernel as well.
- Removes the hacky 5 seconds delay before initialization. Instead we now register the loader interface only when we're connected to the first peer.