### PR TITLE
Prepare a second bootnode

### DIFF
--- a/.maintain/node-deploy-kube-config.yml
+++ b/.maintain/node-deploy-kube-config.yml
@@ -29,7 +29,7 @@ metadata:
   name: passive-node
 spec:
   serviceName: passive-node
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: passive-node
@@ -62,11 +62,16 @@ spec:
         env:
         - name: RUST_LOG
           value: p2p_loader=TRACE
-        - name: PRIVATE_KEY
+        - name: PRIVATE_KEY_BASE
+          # The value in `PRIVATE_KEY_BASE` is combined with `NODE_NAME` to obtain the real actual key.
           valueFrom:
             secretKeyRef:
-              name: p2p-loader-private-key # TODO: we need one key per node :facepalm:
+              name: p2p-loader-private-key
               key: private_key
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         ports:
         - containerPort: 30333
           protocol: TCP

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -87,9 +87,9 @@ where
         }
 
         // TODO: temporary; uncomment to test
-        system_builder = system_builder.with_main_program(
+        /*system_builder = system_builder.with_main_program(
             ModuleHash::from_base58("FWMwRMQCKdWVDdKyx6ogQ8sXuoeDLNzZxniRMyD5S71").unwrap(),
-        );
+        );*/
 
         Kernel {
             system: system_builder.build().expect("failed to start kernel"),

--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -87,9 +87,9 @@ where
         }
 
         // TODO: temporary; uncomment to test
-        /*system_builder = system_builder.with_main_program(
+        system_builder = system_builder.with_main_program(
             ModuleHash::from_base58("FWMwRMQCKdWVDdKyx6ogQ8sXuoeDLNzZxniRMyD5S71").unwrap(),
-        );*/
+        );
 
         Kernel {
             system: system_builder.build().expect("failed to start kernel"),

--- a/modules/p2p-loader/src/bin/passive-node.rs
+++ b/modules/p2p-loader/src/bin/passive-node.rs
@@ -44,17 +44,17 @@ async fn async_main() {
     let cli_opts = CliOptions::from_args();
 
     let mut config = NetworkConfig::default();
-    config.private_key = if let Ok(key) = env::var("PRIVATE_KEY") {
-        let bytes = base64::decode(&key).unwrap();
-        assert_eq!(bytes.len(), 32);
-        let mut out = [0; 32];
-        out.copy_from_slice(&bytes);
-        Some(out)
-    } else {
-        None
-    };
     config.watched_directories = cli_opts.watch;
     config.watched_git_repositories = cli_opts.git_watch;
+    config.private_key = match (env::var("PRIVATE_KEY_BASE"), env::var("NODE_NAME")) {
+        (Ok(key_base), Ok(pod_name)) => {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(&base64::decode(&key_base).unwrap());
+            hasher.update(pod_name.as_bytes());
+            Some(hasher.finalize().into())
+        }
+        _ => None,
+    };
 
     let mut network = Network::<std::convert::Infallible>::start(config).unwrap(); // TODO: use `!`
     loop {

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -191,16 +191,22 @@ impl<T> Network<T> {
             log::warn!("Failed to start listener: {}", err);
         }
 
-        // Bootnode.
+        // Bootnodes.
         swarm.add_address(
             &"12D3KooWCWX1zQ3WXSMGuDK2qgVPgC4itYUkj84AsxBYcafMX6ot"
                 .parse()
                 .unwrap(),
             "/ip4/157.245.20.120/tcp/30333".parse().unwrap(),
         );
+        swarm.add_address(
+            &"12D3KooWCWX1zQ3WXSMGuDK2qgVPgC4itYUkj84AsxBYcafMX6ot"
+                .parse()
+                .unwrap(),
+            "/ip4/68.183.243.252/tcp/30333".parse().unwrap(),
+        );
 
         // Bootstrapping returns an error if we don't know of any other peer to connect to.
-        // This would typically happen on the bootnode itself.
+        // This would normally only happen on the bootnodes themselves.
         let _ = swarm.bootstrap();
 
         Ok(Network {


### PR DESCRIPTION
I didn't update the `PeerId`s because I'm too lazy to figure out what they will be. After deployment, will read them from the nodes and open a second PR.