### PR TITLE
More Kubernetes work

### DIFF
--- a/.maintain/node-deploy-kube-config.yml
+++ b/.maintain/node-deploy-kube-config.yml
@@ -1,4 +1,5 @@
 ---
+# Nodes running a peer-to-peer node expose their TCP port 30333.
 kind: Service
 apiVersion: v1
 metadata:
@@ -18,9 +19,12 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: p2p-loader-private-key
+  name: p2p-loader-private-key-base
 type: Opaque
 data:
+  # Note: the application expects a base64-encoded value, and Kubernetes expects you to give
+  # the base64 encoding of the value to pass to the application. Therefore the value below is the
+  # private key that has been base64-encoded twice.
   private_key: Y0N6UEc3ZE13TUlPSjI1Z0JVRmdDMWNvb1lRbWlaNTRIS2Z6SDJXOEFtUT0=   # TODO: that's not exactly "secret"
 ---
 apiVersion: apps/v1
@@ -66,12 +70,12 @@ spec:
           # The value in `PRIVATE_KEY_BASE` is combined with `NODE_NAME` to obtain the real actual key.
           valueFrom:
             secretKeyRef:
-              name: p2p-loader-private-key
+              name: p2p-loader-private-key-base
               key: private_key
         - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: metadata.name
+              fieldPath: spec.nodeName
         ports:
         - containerPort: 30333
           protocol: TCP

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -193,13 +193,13 @@ impl<T> Network<T> {
 
         // Bootnodes.
         swarm.add_address(
-            &"12D3KooWCWX1zQ3WXSMGuDK2qgVPgC4itYUkj84AsxBYcafMX6ot"
+            &"12D3KooWRx34RaEpD3jjHruSHRW2JTv18uiHDtk82j9cGCWKQVZF"
                 .parse()
                 .unwrap(),
             "/ip4/157.245.20.120/tcp/30333".parse().unwrap(),
         );
         swarm.add_address(
-            &"12D3KooWCWX1zQ3WXSMGuDK2qgVPgC4itYUkj84AsxBYcafMX6ot"
+            &"12D3KooWCodzgHiHEtgYUECQN3RqPPBSRWdV7psnatSqdWHfAqGc"
                 .parse()
                 .unwrap(),
             "/ip4/68.183.243.252/tcp/30333".parse().unwrap(),


### PR DESCRIPTION
cc #482 

Considering that DigitalOcean lets me assign specific IPs to specific nodes, this PR makes bootnodes derive their private key based on the name of the node.
In other words, even if pods jump between nodes, the mapping between IP address and peer ID will stay the same.
