### PR TITLE
Improvements to the p2p-loader

### DIFF
--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309f95fce9bec755eff5406f8b822fd3969990830c2b54f752e1fc181d5ace3e"
+checksum = "9481500c5774c62e8c413e9535b3f33a0e3dbacf2da63b8d3056c686a9df4146"
 dependencies = [
  "async-std",
  "futures",

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -513,9 +513,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -538,15 +538,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -556,15 +556,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -574,15 +574,18 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-timer"
@@ -598,9 +601,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -609,6 +612,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -617,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "futures_codec"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a73299e4718f5452e45980fc1d6957a070abe308d3700b63b8673f47e1c2b3"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes",
  "futures",
@@ -980,9 +984,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libgit2-sys"
@@ -1000,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057eba5432d3e740e313c6e13c9153d0cb76b4f71bfc2e5242ae5bdb7d41af67"
+checksum = "db81113df355dea9dddfcb01cd867555298dca29d915f25d1b1a0aad2e29338b"
 dependencies = [
  "bytes",
  "futures",
@@ -1010,9 +1014,9 @@ dependencies = [
  "libp2p-core",
  "libp2p-core-derive",
  "libp2p-kad",
- "libp2p-mplex",
  "libp2p-plaintext",
  "libp2p-swarm",
+ "libp2p-yamux",
  "multihash",
  "parity-multiaddr",
  "parking_lot",
@@ -1023,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5e30dcd8cb13a02ad534e214da234eca1595a76b5788b645dfa5c734d2124b"
+checksum = "3a0387b930c3d4c2533dc4893c1e0394185ddcc019846121b1b27491e45a2c08"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1050,7 +1054,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "thiserror",
- "unsigned-varint",
+ "unsigned-varint 0.4.0",
  "void",
  "zeroize",
 ]
@@ -1067,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d6c1d5100973527ae70d82687465b17049c1b717a7964de38b8e65000878ff"
+checksum = "f7c819a5425b2eb3416d67e9c868c5c1e922b6658655e06b9eeafaa41304b876"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1087,32 +1091,16 @@ dependencies = [
  "sha2",
  "smallvec",
  "uint",
- "unsigned-varint",
+ "unsigned-varint 0.4.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
-name = "libp2p-mplex"
+name = "libp2p-plaintext"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ce63313ad4bce2d76e54c292a1293ea47a0ebbe16708f1513fa62184992f53"
-dependencies = [
- "bytes",
- "fnv 1.0.7",
- "futures",
- "futures_codec",
- "libp2p-core",
- "log",
- "parking_lot",
- "unsigned-varint",
-]
-
-[[package]]
-name = "libp2p-plaintext"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad28fe7beaa3e516ee8ba2af8c4f6820f269afa60d661831e879f2afea64f4a0"
+checksum = "1743dfb7817febee1545a21b327846ddae4162ac5dc1977ef1c823d4e9e89d44"
 dependencies = [
  "bytes",
  "futures",
@@ -1122,15 +1110,15 @@ dependencies = [
  "prost",
  "prost-build",
  "rw-stream-sink",
- "unsigned-varint",
+ "unsigned-varint 0.4.0",
  "void",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a8101a0e0d5f04562137a476bf5f5423cd5bdab2f7e43a75909668e63cb102"
+checksum = "ce53ff4d127cf8b39adf84dbd381ca32d49bd85788cee08e6669da2495993930"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1155,6 +1143,19 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da33e7b5f49c75c6a8afb0b8d1e229f5fa48be9f39bd14cdbc21459a02ac6fc"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "parking_lot",
+ "thiserror",
+ "yamux",
 ]
 
 [[package]]
@@ -1332,7 +1333,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "sha3",
- "unsigned-varint",
+ "unsigned-varint 0.3.3",
 ]
 
 [[package]]
@@ -1343,16 +1344,16 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991c33683908c588b8f2cf66c221d8f390818c1bdcd13fce55208408e027a796"
+checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
 dependencies = [
  "bytes",
  "futures",
  "log",
  "pin-project",
  "smallvec",
- "unsigned-varint",
+ "unsigned-varint 0.4.0",
 ]
 
 [[package]]
@@ -1490,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ca96399f4a01aa89c59220c4f52ac371940eb4e53e3ce990da796f364bdf69"
+checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
 dependencies = [
  "arrayref",
  "bs58",
@@ -1502,7 +1503,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint",
+ "unsigned-varint 0.4.0",
  "url",
 ]
 
@@ -1586,18 +1587,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.10"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.10"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2403,6 +2404,12 @@ name = "unsigned-varint"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
 dependencies = [
  "bytes",
  "futures_codec",
@@ -2627,6 +2634,20 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yamux"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd37e58a1256a0b328ce9c67d8b62ecdd02f4803ba443df478835cb1a41a637c"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "rand 0.7.3",
+ "static_assertions",
 ]
 
 [[package]]

--- a/modules/p2p-loader/Cargo.toml
+++ b/modules/p2p-loader/Cargo.toml
@@ -27,9 +27,9 @@ walkdir = "2.3.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 env_logger = "0.7.1"
-libp2p-tcp = { version = "0.19.1", default-features = false, features = ["async-std"] }
+libp2p-tcp = { version = "0.19.2", default-features = false, features = ["async-std"] }
 # TODO: use the version below once cargo has fixed the associated bug
-#libp2p = { version = "0.19.1", default-features = false, features = ["tcp"] }
+#libp2p = { version = "0.20.2", default-features = false, features = ["tcp"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 redshirt-interface-interface = { path = "../../interfaces/interface" }

--- a/modules/p2p-loader/Cargo.toml
+++ b/modules/p2p-loader/Cargo.toml
@@ -15,7 +15,7 @@ blake3 = { version = "0.2.2", default-features = false }
 bs58 = "0.3.0"
 futures = "0.3"
 git2 = { version = "0.13.2", optional = true }
-libp2p = { version = "0.19.1", default-features = false, features = ["kad", "mplex", "plaintext"] }
+libp2p = { version = "0.20.1", default-features = false, features = ["kad", "plaintext", "yamux"] }
 log = "0.4"
 notify = { version = "4.0.15", optional = true }
 # openssl-sys is not used directly, but we want to pass the "vendored" feature

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -156,6 +156,7 @@ impl<T> Network<T> {
                 let mut yamux_config = yamux::Config::default();
                 // Only set SYN flag on first data frame sent to the remote.
                 yamux_config.set_lazy_open(true);
+                yamux_config.set_window_update_mode(yamux::WindowUpdateMode::OnRead);
                 yamux_config
             })
             // TODO: timeout

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -177,7 +177,6 @@ impl<T> Network<T> {
             {
                 let mut cfg = KademliaConfig::default();
                 cfg.set_max_packet_size(10 * 1024 * 1024);
-                cfg.set_query_timeout(Duration::from_secs(3600));
                 cfg
             },
         );

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -251,7 +251,10 @@ impl<T> Network<T> {
                     ..
                 })) => {
                     for record in result.records {
-                        log::debug!("Successfully loaded record from DHT: {:?}", record.record.key);
+                        log::debug!(
+                            "Successfully loaded record from DHT: {:?}",
+                            record.record.key
+                        );
                         while let Some(pos) = self
                             .active_fetches
                             .iter()

--- a/modules/p2p-loader/src/lib.rs
+++ b/modules/p2p-loader/src/lib.rs
@@ -28,9 +28,9 @@ use libp2p::kad::{
     record::Key,
     Kademlia, KademliaConfig, KademliaEvent, QueryResult, Quorum,
 };
-use libp2p::mplex::MplexConfig;
 use libp2p::plaintext::PlainText2Config;
 use libp2p::swarm::{Swarm, SwarmEvent};
+use libp2p::yamux;
 use std::{collections::VecDeque, io, path::PathBuf, pin::Pin, time::Duration};
 
 mod git_clones;
@@ -153,9 +153,10 @@ impl<T> Network<T> {
                 local_public_key: local_keypair.public(),
             })
             .multiplex({
-                let mut cfg = MplexConfig::default();
-                cfg.split_send_size(10 * 1024 * 1024);
-                cfg
+                let mut yamux_config = yamux::Config::default();
+                // Only set SYN flag on first data frame sent to the remote.
+                yamux_config.set_lazy_open(true);
+                yamux_config
             })
             // TODO: timeout
             .map(|(id, muxer), _| (id, StreamMuxerBox::new(muxer)))
@@ -175,8 +176,8 @@ impl<T> Network<T> {
             ),
             {
                 let mut cfg = KademliaConfig::default();
-                cfg.set_replication_interval(Some(Duration::from_secs(60)));
                 cfg.set_max_packet_size(10 * 1024 * 1024);
+                cfg.set_query_timeout(Duration::from_secs(3600));
                 cfg
             },
         );
@@ -251,15 +252,15 @@ impl<T> Network<T> {
                     ..
                 })) => {
                     for record in result.records {
-                        log::debug!("Successfully loaded record from DHT: {:?}", record.key);
+                        log::debug!("Successfully loaded record from DHT: {:?}", record.record.key);
                         while let Some(pos) = self
                             .active_fetches
                             .iter()
-                            .position(|(key, _)| *key == record.key)
+                            .position(|(key, _)| *key == record.record.key)
                         {
                             let user_data = self.active_fetches.remove(pos).1;
                             self.events_queue.push_back(NetworkEvent::FetchSuccess {
-                                data: record.value.clone(),
+                                data: record.record.value.clone(),
                                 user_data,
                             });
                         }
@@ -312,7 +313,8 @@ impl<T> Network<T> {
                 }
                 future::Either::Right(Some(notifier::NotifierEvent::InjectDht { hash, data })) => {
                     // TODO: use Quorum::Majority when network is large enough
-                    // TODO: is republication automatic?
+                    // This stores the record in the local storage. Republication on the DHT
+                    // is then automatically handled by `libp2p-kad`.
                     self.swarm
                         .put_record(
                             libp2p::kad::Record::new(hash.to_vec(), data),


### PR DESCRIPTION
Updates to libp2p 0.20.2, switches to using `yamux`, and some small changes.
The switch to yamux is a fix attempt for https://github.com/tomaka/redshirt/issues/330