### PR TITLE
Make the loader_pid an atomic variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
+name = "atomic"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f46ca51dca4837f1520754d1c8c36636356b81553d928dc9c177025369a06e"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1616,7 @@ dependencies = [
 name = "redshirt-core"
 version = "0.1.0"
 dependencies = [
+ "atomic",
  "blake3",
  "bs58",
  "criterion",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 nightly = ["redshirt-core-proc-macros/nightly"]
 
 [dependencies]
+atomic = "0.4.6"
 blake3 = { version = "0.2.2", default-features = false }
 bs58 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 crossbeam-queue = { version = "0.2.1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This seems quite important considering that it is read all the time.

The reason why it isn't already an atomic is that `AtomicU64` isn't available on all platforms. The cool `atomic` library solves this problem.