### PR TITLE
Minor changes regarding CPUID

### DIFF
--- a/kernel/standalone/src/arch/x86_64/apic/timers.rs
+++ b/kernel/standalone/src/arch/x86_64/apic/timers.rs
@@ -114,7 +114,7 @@ pub async fn init(
     pit: &mut pit::PitControl,
 ) -> Arc<Timers> {
     // We don't support systems without the TSC.
-    asser!(is_tsc_supported());
+    assert!(is_tsc_supported());
 
     // We use the PIT to figure out approximately how many RDTSC ticks happen per second.
     // TODO: instead of using the PIT, we can use CPUID[EAX=0x15] to find the frequency, but that

--- a/kernel/standalone/src/arch/x86_64/apic/timers.rs
+++ b/kernel/standalone/src/arch/x86_64/apic/timers.rs
@@ -113,7 +113,8 @@ pub async fn init(
     local_apics: &'static local::LocalApicsControl,
     pit: &mut pit::PitControl,
 ) -> Arc<Timers> {
-    // TODO: check if TSC is supported somewhere with CPUID.1:EDX.TSC[bit 4] == 1
+    // We don't support systems without the TSC.
+    asser!(is_tsc_supported());
 
     // We use the PIT to figure out approximately how many RDTSC ticks happen per second.
     // TODO: instead of using the PIT, we can use CPUID[EAX=0x15] to find the frequency, but that
@@ -605,5 +606,13 @@ fn configure_apic(
         apic_timer_firing_tsc_value: NonZeroU64::new(tsc_now.checked_add(ticks_to_timer).unwrap())
             .unwrap(),
         timer: entry,
+    }
+}
+
+/// Checks in the CPUID whether the TSC is supported.
+fn is_tsc_supported() -> bool {
+    unsafe {
+        let cpuid = core::arch::x86_64::__cpuid(0x1);
+        cpuid.edx & (1 << 4) != 0
     }
 }


### PR DESCRIPTION
- Removes the `TODO: has_cpuid()` checks, as this method is planned to be removed. If `cpuid` isn't supported then we'll get a panic for illegal instruction anyway, and having an `assert` failure doesn't change much.

- Removes the constant-rate APIC timer check, as it's not supported by AMD.

- Checks for TSC support.
