### PR TITLE
Various fixes to timers

### DIFF
--- a/kernel/standalone/src/arch/x86_64.rs
+++ b/kernel/standalone/src/arch/x86_64.rs
@@ -453,7 +453,9 @@ impl PlatformSpecific for PlatformSpecificImpl {
     }
 
     fn timer(self: Pin<&Self>, clock_value: u128) -> Self::TimerFuture {
-        self.timers.register_timer({
+        self.timers.register_timer_at({
+            // `unwrap_or(u64::max_value())` means that any wait longer than 2^64 seconds will be
+            // clamped to 2^64 seconds. We don't expect any system to ever run for 2^64 seconds.
             let secs = u64::try_from(clock_value / 1_000_000_000).unwrap_or(u64::max_value());
             let nanos = u32::try_from(clock_value % 1_000_000_000).unwrap();
             Duration::new(secs, nanos)

--- a/kernel/standalone/src/arch/x86_64/ap_boot.rs
+++ b/kernel/standalone/src/arch/x86_64/ap_boot.rs
@@ -168,7 +168,7 @@ pub unsafe fn boot_associated_processor(
     local_apics.send_interprocessor_init(target);
 
     // Later we will wait for 10ms to have elapsed since the INIT.
-    let wait_after_init = timers.register_timer(Duration::from_millis(10));
+    let wait_after_init = timers.register_timer_after(Duration::from_millis(10));
 
     // Write the template code to the buffer.
     ptr::copy_nonoverlapping(
@@ -319,7 +319,7 @@ pub unsafe fn boot_associated_processor(
 
         // Wait for the processor initialization to finish, but with a timeout in order to not
         // wait forever if nothing happens.
-        let ap_ready_timeout = timers.register_timer(Duration::from_secs(1));
+        let ap_ready_timeout = timers.register_timer_after(Duration::from_secs(1));
         futures::pin_mut!(ap_ready_timeout);
         match executor.block_on(future::select(ap_ready_timeout, &mut init_finished_future)) {
             future::Either::Left(_) => continue,

--- a/kernel/standalone/src/time.rs
+++ b/kernel/standalone/src/time.rs
@@ -33,11 +33,13 @@ pub struct TimeHandler<TPlat> {
     /// Platform-specific hooks.
     platform_specific: Pin<Arc<TPlat>>,
     /// Sending side of `pending_messages`.
-    pending_messages_tx: future_channel::UnboundedSender<Option<(MessageId, Result<EncodedMessage, ()>)>>,
+    pending_messages_tx:
+        future_channel::UnboundedSender<Option<(MessageId, Result<EncodedMessage, ()>)>>,
     /// List of messages waiting to be emitted with `next_event`. Can also contain dummy events
     /// (`None`) if we just need to wake up the receiving task after having pushed an element on
     /// `timers`.
-    pending_messages: future_channel::UnboundedReceiver<Option<(MessageId, Result<EncodedMessage, ()>)>>,
+    pending_messages:
+        future_channel::UnboundedReceiver<Option<(MessageId, Result<EncodedMessage, ()>)>>,
     /// List of active timers.
     timers: Spinlock<FuturesUnordered<Pin<Box<dyn Future<Output = MessageId> + Send>>>>,
 }
@@ -128,8 +130,7 @@ where
                         .map(move |_| message_id)
                         .boxed(),
                 );
-                self.pending_messages_tx
-                    .unbounded_send(None);
+                self.pending_messages_tx.unbounded_send(None);
             }
             Err(_) => {
                 self.pending_messages_tx

--- a/kernel/standalone/src/time.rs
+++ b/kernel/standalone/src/time.rs
@@ -33,9 +33,11 @@ pub struct TimeHandler<TPlat> {
     /// Platform-specific hooks.
     platform_specific: Pin<Arc<TPlat>>,
     /// Sending side of `pending_messages`.
-    pending_messages_tx: future_channel::UnboundedSender<(MessageId, Result<EncodedMessage, ()>)>,
-    /// List of messages waiting to be emitted with `next_event`.
-    pending_messages: future_channel::UnboundedReceiver<(MessageId, Result<EncodedMessage, ()>)>,
+    pending_messages_tx: future_channel::UnboundedSender<Option<(MessageId, Result<EncodedMessage, ()>)>>,
+    /// List of messages waiting to be emitted with `next_event`. Can also contain dummy events
+    /// (`None`) if we just need to wake up the receiving task after having pushed an element on
+    /// `timers`.
+    pending_messages: future_channel::UnboundedReceiver<Option<(MessageId, Result<EncodedMessage, ()>)>>,
     /// List of active timers.
     timers: Spinlock<FuturesUnordered<Pin<Box<dyn Future<Output = MessageId> + Send>>>>,
 }
@@ -43,11 +45,6 @@ pub struct TimeHandler<TPlat> {
 impl<TPlat> TimeHandler<TPlat> {
     /// Initializes the new state machine for time accesses.
     pub fn new(platform_specific: Pin<Arc<TPlat>>) -> Self {
-        let timers = FuturesUnordered::new();
-        // We don't want `timers` to ever produce `None`, so we push a dummy futures.
-        // TODO: remove that
-        timers.push(future::pending().boxed());
-
         let (pending_messages_tx, pending_messages) = future_channel::channel();
 
         TimeHandler {
@@ -55,7 +52,7 @@ impl<TPlat> TimeHandler<TPlat> {
             platform_specific,
             pending_messages_tx,
             pending_messages,
-            timers: Spinlock::new(timers),
+            timers: Spinlock::new(FuturesUnordered::new()),
         }
     }
 }
@@ -82,18 +79,24 @@ where
             }
 
             future::poll_fn(move |cx| {
-                if let Poll::Ready((message_id, answer)) = self.pending_messages.poll_next(cx) {
-                    return Poll::Ready(NativeProgramEvent::Answer { message_id, answer });
+                while let Poll::Ready(msg) = self.pending_messages.poll_next(cx) {
+                    if let Some((message_id, answer)) = msg {
+                        return Poll::Ready(NativeProgramEvent::Answer { message_id, answer });
+                    }
                 }
 
                 let mut timers = self.timers.lock();
-                match Stream::poll_next(Pin::new(&mut *timers), cx) {
-                    Poll::Ready(Some(message_id)) => Poll::Ready(NativeProgramEvent::Answer {
-                        message_id,
-                        answer: Ok(().encode()),
-                    }),
-                    Poll::Ready(None) => unreachable!(),
-                    Poll::Pending => Poll::Pending,
+                if !timers.is_empty() {
+                    match Stream::poll_next(Pin::new(&mut *timers), cx) {
+                        Poll::Ready(Some(message_id)) => Poll::Ready(NativeProgramEvent::Answer {
+                            message_id,
+                            answer: Ok(().encode()),
+                        }),
+                        Poll::Ready(None) => unreachable!(),
+                        Poll::Pending => Poll::Pending,
+                    }
+                } else {
+                    Poll::Pending
                 }
             })
             .await
@@ -113,7 +116,7 @@ where
             Ok(TimeMessage::GetMonotonic) => {
                 let now = self.platform_specific.as_ref().monotonic_clock();
                 self.pending_messages_tx
-                    .unbounded_send((message_id.unwrap(), Ok(now.encode())));
+                    .unbounded_send(Some((message_id.unwrap(), Ok(now.encode()))));
             }
             Ok(TimeMessage::WaitMonotonic(value)) => {
                 let message_id = message_id.unwrap();
@@ -124,11 +127,13 @@ where
                         .timer(value)
                         .map(move |_| message_id)
                         .boxed(),
-                )
+                );
+                self.pending_messages_tx
+                    .unbounded_send(None);
             }
             Err(_) => {
                 self.pending_messages_tx
-                    .unbounded_send((message_id.unwrap(), Err(())));
+                    .unbounded_send(Some((message_id.unwrap(), Err(()))));
             }
         }
     }


### PR DESCRIPTION
Probably one of the biggest stupidities I've done so far. `register_timer_at` and `register_timer_after` were mixed.
If 20 seconds after the system start-up you called `Delay::new(Duration::from_secs(1))`, then it would actually wait for 21 seconds.

This is a huge fix that fixes a lot of things behaving in a weird way.