### PR TITLE
Restore clamping to 0xffff for PCI I/O ports

### DIFF
--- a/kernel/standalone/src/pci/pci.rs
+++ b/kernel/standalone/src/pci/pci.rs
@@ -340,7 +340,9 @@ fn scan_function(bdf: &DeviceBdf) -> Option<ScanResult> {
                         bar_n += 2;
                     }
                 } else {
-                    let base_address = u16::try_from(bar & !0b11).unwrap();
+                    // TODO: this ` & 0xffff` is normally not needed, but it seems like on real
+                    // hardware the value is higher than 0xffff
+                    let base_address = u16::try_from((bar & !0b11) & 0xffff).unwrap();
                     list.push(BaseAddressRegister::Io { base_address });
                     bar_n += 1;
                 }


### PR DESCRIPTION
I had removed this check because I thought this was a faulty situation resulting from not handlint 64bits addresses at the time.
In practice, the I/O ports values do go above 0xffff on my Thinkpad X1.