### PR TITLE
Make HTTP server expose kernel metrics

### DIFF
--- a/kernel/standalone/src/kernel.rs
+++ b/kernel/standalone/src/kernel.rs
@@ -42,7 +42,6 @@ pub struct Kernel<TPlat> {
     /// Contains the list of all processes, threads, interfaces, messages, and so on.
     system: System<'static, WasiExtrinsics>,
     /// Has one entry for each CPU. Never resized.
-    // TODO: add a way to report these values, see https://github.com/tomaka/redshirt/issues/117
     cpu_busy_counters: Vec<CpuCounter>,
     /// Platform-specific getters. Passed at initialization.
     platform_specific: Pin<Arc<TPlat>>,

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "futures",
  "hyper",
  "log",
+ "redshirt-kernel-debug-interface",
  "redshirt-log-interface",
  "redshirt-syscalls",
  "redshirt-tcp-interface",

--- a/modules/http-server/Cargo.toml
+++ b/modules/http-server/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 futures = "0.3.1"
 hyper = { version = "0.13.1", default-features = false }
 log = "0.4.8"
+redshirt-kernel-debug-interface = { path = "../../interfaces/kernel-debug" }
 redshirt-log-interface = { path = "../../interfaces/log" }
 redshirt-syscalls = { path = "../../interfaces/syscalls" }
 redshirt-tcp-interface = { path = "../../interfaces/tcp" }


### PR DESCRIPTION
Fix #525 

One can now connect the Prometheus scraper to the kernel and see for example the CPU usage over time:

![Screenshot from 2020-08-01 15-18-39](https://user-images.githubusercontent.com/1412254/89102510-4cb65280-d40a-11ea-937a-57ba91b99020.png)

(CPU 1 isn't visible above because of [this todo](https://github.com/tomaka/redshirt/blob/7d80254aec50967fee95209f9f788a89501efaee/kernel/standalone/src/kernel.rs#L153-L155))
