### PR TITLE
Update to hashbrown 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,12 +881,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.7.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "autocfg",
-]
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "heck"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ crossbeam-queue = { version = "0.2.1", default-features = false, features = ["al
 either = { version = "1.5.3", default-features = false }
 fnv = { git = "https://github.com/dflemstr/rust-fnv", default-features = false }    # TODO: https://github.com/servo/rust-fnv/pull/22
 futures = { version = "0.3.4", default-features = false }
-hashbrown = { version = "0.7.1", default-features = false }
+hashbrown = { version = "0.9.0", default-features = false }
 nohash-hasher = { version = "0.2.0", default-features = false }
 redshirt-core-proc-macros = { path = "../core-proc-macros" }
 redshirt-interface-interface = { path = "../interfaces/interface", default-features = false }

--- a/interfaces/syscalls/Cargo.toml
+++ b/interfaces/syscalls/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 futures = { version = "0.3.1", default-features = false, features = ["alloc"] }
 generic-array = { version = "0.13.2", default-features = false }
-hashbrown = { version = "0.7.1", default-features = false }
+hashbrown = { version = "0.9.0", default-features = false }
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 nohash-hasher = { version = "0.2.0", default-features = false }
 parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }

--- a/kernel/standalone/Cargo.toml
+++ b/kernel/standalone/Cargo.toml
@@ -14,7 +14,7 @@ derive_more = "0.99.8"
 either = { version = "1.5.3", default-features = false }
 fnv = { git = "https://github.com/dflemstr/rust-fnv", default-features = false }    # TODO: https://github.com/servo/rust-fnv/pull/22
 futures = { version = "0.3.2", default-features = false, features = ["alloc"] }
-hashbrown = { version = "0.7.1", default-features = false }
+hashbrown = { version = "0.9.0", default-features = false }
 lazy_static = "1.4"
 libm = "0.2.1"
 linked_list_allocator = { version = "0.8.2", features = ["alloc_ref"] }

--- a/kernel/standalone/src/arch/x86_64/apic/timers.rs
+++ b/kernel/standalone/src/arch/x86_64/apic/timers.rs
@@ -465,7 +465,7 @@ impl futures::task::ArcWake for TimerWaker {
         // Remove from `active_timers` all the timers that have fired.
         for (_, timer) in shared
             .active_timers
-            .drain_filter(|_, timer| timer.apic_timer_firing_tsc_value.get() > now)
+            .drain_filter(|_, timer| timer.apic_timer_firing_tsc_value.get() <= now)
         {
             debug_assert!(timer.apic_timer_firing_tsc_value.get() <= now);
             if timer.timer.target_tsc_value.get() <= now {

--- a/modules/Cargo.lock
+++ b/modules/Cargo.lock
@@ -151,12 +151,6 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-
-[[package]]
-name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -442,7 +436,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "cfg-if",
  "lazy_static",
 ]
@@ -888,21 +882,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.6.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
-dependencies = [
- "autocfg 0.1.7",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "autocfg 1.0.0",
-]
+checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
 name = "heck"
@@ -1041,7 +1023,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -1520,7 +1502,7 @@ version = "0.1.0"
 dependencies = [
  "fnv 1.0.7",
  "futures",
- "hashbrown 0.6.3",
+ "hashbrown",
  "log",
  "parity-scale-codec",
  "rand 0.7.3",
@@ -1607,7 +1589,7 @@ version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7717097d810a0f2e2323f9e5d11e71608355e24828410b55b9d4f18aa5f9a5d8"
 dependencies = [
- "autocfg 1.0.0",
+ "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -1718,7 +1700,7 @@ name = "pci-printer"
 version = "0.1.0"
 dependencies = [
  "fnv 1.0.6",
- "hashbrown 0.7.2",
+ "hashbrown",
  "lazy_static",
  "log",
  "parity-scale-codec",
@@ -2102,7 +2084,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "generic-array 0.13.2",
- "hashbrown 0.7.2",
+ "hashbrown",
  "lazy_static",
  "nohash-hasher",
  "parity-scale-codec",

--- a/modules/network-manager/Cargo.toml
+++ b/modules/network-manager/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 fnv = { version = "1.0.7", default-features = false }
 futures = "0.3"
-hashbrown = { version = "0.6.3", default-features = false }
+hashbrown = { version = "0.9.0", default-features = false }
 log = "0.4"
 parity-scale-codec = "1.0.5"
 rand = "0.7.3"

--- a/modules/pci-printer/Cargo.toml
+++ b/modules/pci-printer/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 fnv = { git = "https://github.com/dflemstr/rust-fnv", default-features = false }    # TODO: https://github.com/servo/rust-fnv/pull/22
-hashbrown = { version = "0.7.1", default-features = false }
+hashbrown = { version = "0.9.0", default-features = false }
 lazy_static = "1"
 log = "0.4"
 redshirt-pci-interface = { path = "../../interfaces/pci" }


### PR DESCRIPTION
The behavior of `drain_filter` has changed in this release:

https://github.com/rust-lang/hashbrown/issues/186