### PR TITLE
Some fixes to the RISC-V kernel

### DIFF
--- a/kernel/standalone/src/arch/riscv/log.rs
+++ b/kernel/standalone/src/arch/riscv/log.rs
@@ -17,9 +17,7 @@
 
 use crate::klog::KLogger;
 
-use alloc::sync::Arc;
 use core::fmt::Write as _;
-use redshirt_kernel_log_interface::ffi::{FramebufferFormat, FramebufferInfo, KernelLogMethod};
 use spinning_top::Spinlock;
 
 /// Modifies the logger to use when printing a panic.
@@ -58,7 +56,7 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
     // Freeze forever.
     loop {
         unsafe {
-            llvm_asm!("wfi");
+            asm!("wfi", options(nomem, nostack, preserves_flags));
         }
     }
 }


### PR DESCRIPTION
The RISC-V kernel doesn't actually work because there's way too little memory (16 kiB) on the HiFive, which is what we target by default.
However, here are some warning fixes and replacement of `llvm_asm!` with `asm!`.