### PR TITLE
Replace all remaining llvm_asm! with asm!

### DIFF
--- a/kernel/standalone/src/arch/arm/executor.rs
+++ b/kernel/standalone/src/arch/arm/executor.rs
@@ -56,7 +56,7 @@ pub fn block_on<R>(future: impl Future<Output = R>) -> R {
             // Thanks to this, if an event happens between the moment when we check the value of
             // `local_waken.woken_up` and the moment when we call `wfe`, then the `wfe`
             // instruction will immediately return and we will check the value again.
-            unsafe { llvm_asm!("wfe" :::: "volatile") }
+            unsafe { asm!("wfe", options(nomem, nostack, preserves_flags)) }
         }
     }
 }
@@ -72,7 +72,7 @@ impl ArcWake for LocalWake {
             // Wakes up all the CPUs that called `wfe`.
             // Note that this wakes up *all* CPUs, but the ARM architecture doesn't provide any
             // way to target a single CPU for wake-up.
-            llvm_asm!("dsb sy ; sev" :::: "volatile")
+            asm!("dsb sy ; sev", options(nomem, nostack, preserves_flags))
         }
     }
 }

--- a/kernel/standalone/src/arch/arm/log.rs
+++ b/kernel/standalone/src/arch/arm/log.rs
@@ -58,7 +58,7 @@ fn panic(panic_info: &core::panic::PanicInfo) -> ! {
     // Freeze forever.
     unsafe {
         loop {
-            llvm_asm!(r#"wfe"#);
+            asm!("wfe", options(nomem, nostack, preserves_flags));
         }
     }
 }

--- a/kernel/standalone/src/arch/arm/time_aarch64.rs
+++ b/kernel/standalone/src/arch/arm/time_aarch64.rs
@@ -38,7 +38,7 @@ impl TimeControl {
         unsafe {
             // TODO: stub
             let val: u64;
-            llvm_asm!("mrs $0, CNTPCT_EL0": "=r"(val) ::: "volatile");
+            asm!("mrs {}, CNTPCT_EL0", out(reg) val, options(nostack, nomem, preserves_flags));
             u128::from(val)
         }
     }

--- a/kernel/standalone/src/arch/arm/time_arm.rs
+++ b/kernel/standalone/src/arch/arm/time_arm.rs
@@ -98,7 +98,7 @@ impl TimeControl {
     pub unsafe fn init() -> Arc<TimeControl> {
         // Initialize the physical counter frequency.
         // TODO: I think this is a global setting, but make sure it's the case?
-        llvm_asm!("mcr p15, 0, $0, c14, c0, 0"::"r"(CNTFRQ)::"volatile");
+        asm!("mcr p15, 0, {}, c14, c0, 0", in(reg) CNTFRQ, options(nomem, nostack, preserves_flags));
 
         // TODO: this code doesn't work, as we have to register some IRQ handler or something to
         //       check the state of the timers and fire the wakers
@@ -229,7 +229,7 @@ fn physical_counter() -> u64 {
     unsafe {
         let lo: u32;
         let hi: u32;
-        llvm_asm!("mrrc p15, 0, $0, $1, c14": "=r"(lo), "=r"(hi) ::: "volatile");
+        asm!("mrrc p15, 0, {}, {}, c14", out(reg) lo, out(reg) hi, options(nostack, nomem, preserves_flags));
         u64::from(hi) << 32 | u64::from(lo)
     }
 }
@@ -243,13 +243,13 @@ fn update_hardware(timers: &mut Vec<Timer>) {
         // If there's no active timer, disable the timer firing by updating the `CNTP_CTL`
         // register.
         if timers.is_empty() {
-            llvm_asm!("mcr p15, 0, $0, c14, c2, 1" :: "r"(0));
+            asm!("mcr p15, 0, {}, c14, c2, 1", in(reg) 0);
             return;
         }
 
         // Make sure that the timer is enabled by updating the `CNTP_CTL` register.
         // TODO: don't do this every single time
-        llvm_asm!("mcr p15, 0, $0, c14, c2, 1" :: "r"(0b01));
+        asm!("mcr p15, 0, {}, c14, c2, 1", in(reg) 0b01);
 
         // Write the `CNTP_CVAL` register with the value to compare with.
         // The timer will fire when the physical counter (`CNTPCT`) reaches the given value.
@@ -257,7 +257,7 @@ fn update_hardware(timers: &mut Vec<Timer>) {
             let cmp_value = timers.get(0).unwrap().counter_value;
             let lo = u32::try_from(cmp_value & 0xffffffff).unwrap();
             let hi = u32::try_from(cmp_value >> 32).unwrap();
-            llvm_asm!("mcrr p15, 2, $0, $1, c14" :: "r"(lo), "r"(hi));
+            asm!("mcrr p15, 2, {}, {}, c14", in(reg) lo, in(reg) hi);
         }
     }
 }

--- a/kernel/standalone/src/arch/riscv.rs
+++ b/kernel/standalone/src/arch/riscv.rs
@@ -192,9 +192,9 @@ impl PlatformSpecificImpl {
                 let hi1: u32;
                 let hi2: u32;
 
-                // Note that we put all three instructions in the same `llvm_asm!`, to prevent the
-                // compiler from reordering them.
-                llvm_asm!("rdtimeh $0 ; rdtime $1 ; rdtimeh $2" : "=r"(hi1), "=r"(lo), "=r"(hi2));
+                // Note that we put all three instructions in the same `asm!`, to prevent the
+                // compiler from possibly reordering them.
+                asm!("rdtimeh {} ; rdtime {} ; rdtimeh {}", out(reg) hi1, out(reg) lo, out(reg) hi2);
 
                 if hi1 == hi2 {
                     break (u64::from(hi1) << 32) | u64::from(lo);
@@ -211,7 +211,7 @@ impl PlatformSpecificImpl {
         // TODO: this is only supported in the "I" version of RISC-V; check that
         unsafe {
             let val: u64;
-            llvm_asm!("rdtime $0" : "=r"(val));
+            asm!("rdtime {}", out(reg) reg);
             u128::from(val)
         }
     }

--- a/kernel/standalone/src/main.rs
+++ b/kernel/standalone/src/main.rs
@@ -20,7 +20,6 @@
 #![feature(allocator_api)] // TODO: https://github.com/rust-lang/rust/issues/32838
 #![feature(alloc_error_handler)] // TODO: https://github.com/rust-lang/rust/issues/66741
 #![feature(asm)] // TODO: https://github.com/rust-lang/rust/issues/72016
-#![feature(llvm_asm)] // TODO: replace all occurrences of `llvm_asm!` with `asm!`
 #![feature(naked_functions)] // TODO: https://github.com/rust-lang/rust/issues/32408
 #![feature(panic_info_message)] // TODO: https://github.com/rust-lang/rust/issues/66745
 #![cfg_attr(target_arch = "x86_64", feature(abi_x86_interrupt))] // TODO: https://github.com/rust-lang/rust/issues/40180


### PR DESCRIPTION
Removes usage of the `llvm_asm` feature.

cc #300 