### PR TITLE
Turn the standalone kernel into a library

### DIFF
--- a/core-proc-macros/src/lib.rs
+++ b/core-proc-macros/src/lib.rs
@@ -213,7 +213,10 @@ pub fn build_wasm_module(tokens: proc_macro::TokenStream) -> proc_macro::TokenSt
                                   // TODO: this is missing Cargo.tomls and stuff I think
         list_iter
             .filter_map(|file| {
-                if Path::new(file).exists() {
+                if !Path::new(file).is_absolute() {
+                    // TODO: relative paths cause issues ; figure out why some paths are relative
+                    None
+                } else if Path::new(file).exists() {
                     // TODO: figure out why some files are missing
                     Some(file.to_owned())
                 } else {

--- a/kernel/standalone-builder/Cargo.lock
+++ b/kernel/standalone-builder/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
+ "toml",
  "walkdir",
 ]
 
@@ -656,6 +657,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/kernel/standalone-builder/Cargo.toml
+++ b/kernel/standalone-builder/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0.61"
 structopt = "0.3.21"
 tempdir = "0.3.7"
 thiserror = "1.0"
+toml = "0.5.8"
 walkdir = "2.3.1"
 
 [profile.dev]

--- a/kernel/standalone-builder/src/bin/main.rs
+++ b/kernel/standalone-builder/src/bin/main.rs
@@ -28,10 +28,13 @@ use structopt::StructOpt;
 enum CliOptions {
     /// Builds and runs the kernel in an emulator.
     EmulatorRun {
-        /// Location of the Cargo.toml of the standalone kernel.
+        /// Location of the Cargo.toml of the standalone kernel library.
         ///
         /// If no value is passed, this the file structure is the one of the upstream repository
         /// and try to find the path in a sibling directory.
+        ///
+        /// It is intended that in the future this can be substituted with the path to a build
+        /// directory, in which case the standalone kernel library gets fetched from crates.io.
         #[structopt(long, parse(from_os_str))]
         kernel_cargo_toml: Option<PathBuf>,
 
@@ -50,10 +53,13 @@ enum CliOptions {
 
     /// Builds a bootable image.
     BuildImage {
-        /// Location of the Cargo.toml of the standalone kernel.
+        /// Location of the Cargo.toml of the standalone kernel library.
         ///
         /// If no value is passed, this the file structure is the one of the upstream repository
         /// and try to find the path in a sibling directory.
+        ///
+        /// It is intended that in the future this can be substituted with the path to a build
+        /// directory, in which case the standalone kernel library gets fetched from crates.io.
         #[structopt(long, parse(from_os_str))]
         kernel_cargo_toml: Option<PathBuf>,
 

--- a/kernel/standalone-builder/src/build.rs
+++ b/kernel/standalone-builder/src/build.rs
@@ -78,7 +78,10 @@ pub fn build(cfg: Config) -> Result<BuildOutput, Error> {
             .exec()
             .map_err(|_| Error::MetadataFailed)?;
 
-        let target_dir_with_target = metadata.target_directory.join(cfg.target_name).join("project");
+        let target_dir_with_target = metadata
+            .target_directory
+            .join(cfg.target_name)
+            .join("project");
 
         let output_file = target_dir_with_target
             .join("target")

--- a/kernel/standalone-builder/src/lib.rs
+++ b/kernel/standalone-builder/src/lib.rs
@@ -14,51 +14,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 //! Collection of commands that can build a kernel.
-//!
-//! # Kernel environment
-//!
-//! This crate doesn't contain the source code of the kernel. Instead, many of the commands require
-//! you to pass the location of a `Cargo.toml` that will build this kernel.
-//!
-//! This crate, however, is responsible for building bootable images and setting up the boot
-//! process on various targets. It therefore sets up an environment that the kernel can expect
-//! to be there.
-//!
-//! This environment is the following:
-//!
-//! - The kernel must provide a symbol named `_start`. Execution will jump to this symbol, after
-//! which the kernel is in total control of the hardware.
-//! - The kernel cannot make any assumption about the state of the registers, memory, or hardware
-//! when `_start` is executed, with some exceptions depending on the target.
-//! - The symbols `__bss_start` and `__bss_end` exist and correspond to the beginning and end
-//! of the BSS section (see below).
-//!
-//! ## BSS section
-//!
-//! The BSS section is the section, in an ELF binary, where all the static variables whose initial
-//! value is all zeroes are located.
-//!
-//! Normally, it is the role of the ELF loader (e.g. the Linux kernel) to ensure that this section
-//! is initialized with zeroes. Operating systems, however, are generally not loaded by an ELF
-//! loader.
-//!
-//! Consequently, when the kernel starts, it **must** write the memory between the `__bss_start`
-//! and `__bss_end` symbols with all zeroes.
-//!
-//! This can be done like this:
-//!
-//! ```norun
-//! let mut ptr = &mut __bss_start as *mut u8;
-//! while ptr < &mut __bss_end as *mut u8 {
-//!     ptr.write_volatile(0);
-//!     ptr = ptr.add(1);
-//! }
-//!
-//! extern "C" {
-//!     static mut __bss_start: u8;
-//!     static mut __bss_end: u8;
-//! }
-//! ```
 
 pub mod binary;
 pub mod build;

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -33,18 +33,21 @@ pub mod time_arm;
 
 mod misc;
 
+#[macro_export]
 macro_rules! __gen_boot {
     (
-        entry: $entry:ident,
-        bss_start: $bss_start:ident,
-        bss_end: $bss_end:ident,
+        entry: $entry:path,
+        memory_zeroing_start: $memory_zeroing_start:path,
+        memory_zeroing_end: $memory_zeroing_end:path,
     ) => {
         const _: () = {
-            use crate::klog::KLogger;
+            extern crate alloc;
+
+            use $crate::klog::KLogger;
             use alloc::sync::Arc;
             use core::{convert::TryFrom as _, iter, num::NonZeroU32, pin::Pin};
-            use futures::prelude::*;
-            use redshirt_kernel_log_interface::ffi::{KernelLogMethod, UartInfo};
+            use $crate::futures::prelude::*;
+            use $crate::redshirt_kernel_log_interface::ffi::{KernelLogMethod, UartInfo};
 
             /// This is the main entry point of the kernel for ARM 32bits architectures.
             #[cfg(target_arch = "arm")]
@@ -75,10 +78,10 @@ macro_rules! __gen_boot {
 
                 // Only one CPU reaches here.
 
-                // Zero the BSS segment.
+                // Zero the memory requested to be zero'ed.
                 // TODO: that's illegal ; naked functions must only contain an asm! block (for good reasons)
-                let mut ptr = &mut $bss_start as *mut u8;
-                while ptr < &mut $bss_end as *mut u8 {
+                let mut ptr = &mut $memory_zeroing_start as *mut u8;
+                while ptr < &mut $memory_zeroing_end as *mut u8 {
                     ptr.write_volatile(0);
                     ptr = ptr.add(1);
                 }
@@ -115,10 +118,10 @@ macro_rules! __gen_boot {
 
                 // Only one CPU reaches here.
 
-                // Zero the BSS segment.
+                // Zero the memory requested to be zero'ed.
                 // TODO: that's illegal ; naked functions must only contain an asm! block (for good reasons)
-                let mut ptr = &mut $bss_start as *mut u8;
-                while ptr < &mut $bss_end as *mut u8 {
+                let mut ptr = &mut $memory_zeroing_start as *mut u8;
+                while ptr < &mut $memory_zeroing_end as *mut u8 {
                     ptr.write_volatile(0);
                     ptr = ptr.add(1);
                 }
@@ -145,7 +148,7 @@ macro_rules! __gen_boot {
 
                 // TODO: RAM starts at 0, but we start later to avoid the kernel
                 // TODO: make this is a cleaner way
-                crate::mem_alloc::initialize(iter::once(0xa000000..0x40000000));
+                $crate::mem_alloc::initialize(iter::once(0xa000000..0x40000000));
 
                 let time = $crate::arch::arm::time::TimeControl::init();
 

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -43,10 +43,10 @@ macro_rules! __gen_boot {
         const _: () = {
             extern crate alloc;
 
-            use $crate::klog::KLogger;
             use alloc::sync::Arc;
             use core::{convert::TryFrom as _, iter, num::NonZeroU32, pin::Pin};
             use $crate::futures::prelude::*;
+            use $crate::klog::KLogger;
             use $crate::redshirt_kernel_log_interface::ffi::{KernelLogMethod, UartInfo};
 
             /// This is the main entry point of the kernel for ARM 32bits architectures.

--- a/kernel/standalone/src/arch/x86_64/boot.rs
+++ b/kernel/standalone/src/arch/x86_64/boot.rs
@@ -230,7 +230,7 @@ macro_rules! __gen_boot {
                 $crate::arch::x86_64::entry_point_step3(multiboot_info, $entry)
             }
 
-            // TODO: the kernel breaks if the linker puts the symbols below too far away ; make this fool proof
+            // TODO: consider moving this out of the macro (but make sure the kernel doesn't break)
 
             #[doc(hidden)]
             const MAIN_PROCESSOR_STACK_SIZE: usize = 0x800000;

--- a/kernel/standalone/src/lib.rs
+++ b/kernel/standalone/src/lib.rs
@@ -45,7 +45,6 @@
 //! as a dependency.
 
 #![no_std]
-
 #![feature(allocator_api)] // TODO: https://github.com/rust-lang/rust/issues/32838
 #![feature(alloc_error_handler)] // TODO: https://github.com/rust-lang/rust/issues/66741
 #![feature(asm)] // TODO: https://github.com/rust-lang/rust/issues/72016


### PR DESCRIPTION
Close #689 

Before this PR, the standalone kernel is cross-platform. It uses only the build target (e.g. `x86_64-unknown-multiboot2`) to determine which environment to expect, and documents it.
The kernel also assumes that the linker will provide the `__bss_start` and `__bss_end` symbols. Again, this is documented.

After this PR, the standalone kernel is no longer a binary but a library. It provides a macro called `__gen_boot!` that generates the code necessary to boot the kernel. The difference compared to now is that this macro can be passed more parameters than just the target, which will result in less guessing.
For example, the `__bss_start` and `__bss_end` symbols are now explicitly provided as parameters to the macro.
The user, here the standalone kernel builder, at the same time passes these symbols and ensures that they indeed exist, therefore resulting in less magic.

The intention behind this PR to later make it possible for the standalone kernel builder to parse a DeviceTree file, pass the appropriate memory ranges and CPUs count to the macro, and make sure that the appropriate drivers are included in the kernel. cc #283 

The other intention is to make it possible for the standalone kernel builder to generate test kernels that just boot, test something, and shut down. Again, this is possible thanks to the fact that the kernel is passed everything instead of guessing what its environment is.

Another side effect is that in the future the standalone kernel builder can be truly standalone and fetch the kernel from crates.io. It would simply be a CLI program, which you can `cargo install`. You pass some parameters, and boom you get a kernel. No need to actually clone the source code.
