### PR TITLE
Update target specs for recent Rust versions

### DIFF
--- a/kernel/standalone-builder/res/specs/aarch64-freestanding.json
+++ b/kernel/standalone-builder/res/specs/aarch64-freestanding.json
@@ -1,19 +1,10 @@
 {
-    "abi-blacklist": [
-      "stdcall",
-      "fastcall",
-      "vectorcall",
-      "thiscall",
-      "win64",
-      "sysv64"
-    ],
     "arch": "aarch64",
     "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     "disable-redzone": true,
     "env": "",
     "executables": true,
-    "features": "+strict-align,-neon,-fp-armv8",
-    "is-builtin": true,
+    "features": "+strict-align,+neon,+fp-armv8",
     "linker": "rust-lld",
     "linker-flavor": "ld.lld",
     "linker-is-gnu": true,
@@ -25,5 +16,12 @@
     "target-c-int-width": "32",
     "target-endian": "little",
     "target-pointer-width": "64",
-    "vendor": ""
+    "unsupported-abis": [
+      "stdcall",
+      "fastcall",
+      "vectorcall",
+      "thiscall",
+      "win64",
+      "sysv64"
+    ]
 }

--- a/kernel/standalone-builder/res/specs/arm-freestanding.json
+++ b/kernel/standalone-builder/res/specs/arm-freestanding.json
@@ -1,12 +1,4 @@
 {
-    "abi-blacklist": [
-        "stdcall",
-        "fastcall",
-        "vectorcall",
-        "thiscall",
-        "win64",
-        "sysv64"
-    ],
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
     "emit-debug-gdb-scripts": false,
@@ -24,5 +16,12 @@
     "target-c-int-width": "32",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "vendor": ""
+    "unsupported-abis": [
+        "stdcall",
+        "fastcall",
+        "vectorcall",
+        "thiscall",
+        "win64",
+        "sysv64"
+    ]
 }

--- a/kernel/standalone-builder/res/specs/riscv-hifive.json
+++ b/kernel/standalone-builder/res/specs/riscv-hifive.json
@@ -1,18 +1,4 @@
 {
-    "abi-blacklist": [
-        "cdecl",
-        "stdcall",
-        "fastcall",
-        "vectorcall",
-        "thiscall",
-        "aapcs",
-        "win64",
-        "sysv64",
-        "ptx-kernel",
-        "msp430-interrupt",
-        "x86-interrupt",
-        "amdgpu-kernel"
-    ],
     "arch": "riscv32",
     "cpu": "generic-rv32",
     "data-layout": "e-m:e-p:32:32-i64:64-n32-S128",
@@ -32,5 +18,18 @@
     "target-c-int-width": "32",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "vendor": "unknown"
+    "unsupported-abis": [
+        "cdecl",
+        "stdcall",
+        "fastcall",
+        "vectorcall",
+        "thiscall",
+        "aapcs",
+        "win64",
+        "sysv64",
+        "ptx-kernel",
+        "msp430-interrupt",
+        "x86-interrupt",
+        "amdgpu-kernel"
+    ]
 }

--- a/kernel/standalone-builder/res/specs/x86_64-multiboot2.json
+++ b/kernel/standalone-builder/res/specs/x86_64-multiboot2.json
@@ -21,6 +21,5 @@
     "stack-probes": true,
     "target-c-int-width": "32",
     "target-endian": "little",
-    "target-pointer-width": "64",
-    "vendor": "unknown"
+    "target-pointer-width": "64"
 }

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -146,6 +146,8 @@ macro_rules! __gen_boot {
                     uart: Some($crate::arch::arm::init_uart()),
                 }));
 
+                panic!("test");
+
                 // TODO: RAM starts at 0, but we start later to avoid the kernel
                 // TODO: make this is a cleaner way
                 $crate::mem_alloc::initialize(iter::once(0xa000000..0x40000000));

--- a/kernel/standalone/src/arch/arm.rs
+++ b/kernel/standalone/src/arch/arm.rs
@@ -146,8 +146,6 @@ macro_rules! __gen_boot {
                     uart: Some($crate::arch::arm::init_uart()),
                 }));
 
-                panic!("test");
-
                 // TODO: RAM starts at 0, but we start later to avoid the kernel
                 // TODO: make this is a cleaner way
                 $crate::mem_alloc::initialize(iter::once(0xa000000..0x40000000));


### PR DESCRIPTION
This fixes the Rust compiling segfaulting when compiling for Raspberry Pi.