### PR TITLE
Fix bad x86 stack alignment

### DIFF
--- a/kernel/standalone/src/arch/x86_64/boot.rs
+++ b/kernel/standalone/src/arch/x86_64/boot.rs
@@ -237,8 +237,11 @@ macro_rules! __gen_boot {
 pub const MAIN_PROCESSOR_STACK_SIZE: usize = 0x800000;
 
 /// Stack used by the main processor.
+///
+/// As per x64 calling convention, the stack pointer must always be a multiple of 16. The stack
+/// must therefore have an alignment of 16 as well.
 #[doc(hidden)]
-#[repr(align(8), C)]
+#[repr(align(16), C)]
 pub struct Stack([u8; MAIN_PROCESSOR_STACK_SIZE]);
 pub static mut MAIN_PROCESSOR_STACK: Stack = Stack([0; MAIN_PROCESSOR_STACK_SIZE]);
 


### PR DESCRIPTION
I think that this is what causes of the issues of the kernel not booting after some random changes (e.g. https://github.com/tomaka/redshirt/pull/717#issuecomment-755178969), and it is also a reasonable explanation of why theses issues were happening.