### PR TITLE
Move to upstream `slab`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "redshirt-syscalls",
  "redshirt-system-time-interface",
  "redshirt-time-interface",
- "slab 0.4.2 (git+https://github.com/baloo/slab?rev=88b456131de20750e785655d1e62cd0b6e10d44b)",
+ "slab 0.4.2 (git+https://github.com/tokio-rs/slab?rev=3340fdcf7204584b9ee509beabf3b174a333dfc1)",
  "smallvec",
  "spinning_top 0.2.2",
  "tiny-keccak",
@@ -1181,7 +1181,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "pin-project",
- "slab 0.4.2 (git+https://github.com/baloo/slab?rev=88b456131de20750e785655d1e62cd0b6e10d44b)",
+ "slab 0.4.2 (git+https://github.com/tokio-rs/slab?rev=3340fdcf7204584b9ee509beabf3b174a333dfc1)",
  "spinning_top 0.2.2",
 ]
 
@@ -1389,7 +1389,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "slab"
 version = "0.4.2"
-source = "git+https://github.com/baloo/slab?rev=88b456131de20750e785655d1e62cd0b6e10d44b#88b456131de20750e785655d1e62cd0b6e10d44b"
+source = "git+https://github.com/tokio-rs/slab?rev=3340fdcf7204584b9ee509beabf3b174a333dfc1#3340fdcf7204584b9ee509beabf3b174a333dfc1"
 
 [[package]]
 name = "smallvec"

--- a/interfaces/syscalls/Cargo.toml
+++ b/interfaces/syscalls/Cargo.toml
@@ -13,5 +13,5 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 nohash-hasher = { version = "0.2.0", default-features = false }
 parity-scale-codec = { version = "1.3.6", default-features = false, features = ["derive"] }
 pin-project = "1.0.4"
-slab = { git = "https://github.com/baloo/slab", rev = "88b456131de20750e785655d1e62cd0b6e10d44b" }
+slab = { git = "https://github.com/tokio-rs/slab", default-features = false, rev = "3340fdcf7204584b9ee509beabf3b174a333dfc1" }
 spinning_top = "0.2.2"

--- a/kernel/core/Cargo.toml
+++ b/kernel/core/Cargo.toml
@@ -32,7 +32,7 @@ redshirt-time-interface = { path = "../../interfaces/time", default-features = f
 rand = { version = "0.8.0", default-features = false }
 rand_chacha = { version = "0.3.0", default-features = false }
 rand_core = { version = "0.6.0", default-features = false }
-slab = { git = "https://github.com/baloo/slab", rev = "88b456131de20750e785655d1e62cd0b6e10d44b" }
+slab = { git = "https://github.com/tokio-rs/slab", default-features = false, rev = "3340fdcf7204584b9ee509beabf3b174a333dfc1" }
 smallvec = { version = "1.6.1", default-features = false }
 spinning_top = "0.2.2"
 wasi = { git = "https://github.com/bytecodealliance/wasi", rev = "45536ac956a6211e3cff047f36cf19d6da82fd95", default-features = false }# TODO: dependabot cannot parse the versioning scheme (`0.10.0+wasi-snapshot-preview1`) of this crate on crates.io

--- a/programs/Cargo.lock
+++ b/programs/Cargo.lock
@@ -2203,7 +2203,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "pin-project 1.0.4",
- "slab 0.4.2 (git+https://github.com/baloo/slab?rev=88b456131de20750e785655d1e62cd0b6e10d44b)",
+ "slab 0.4.2 (git+https://github.com/tokio-rs/slab?rev=3340fdcf7204584b9ee509beabf3b174a333dfc1)",
  "spinning_top",
 ]
 
@@ -2428,7 +2428,7 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 [[package]]
 name = "slab"
 version = "0.4.2"
-source = "git+https://github.com/baloo/slab?rev=88b456131de20750e785655d1e62cd0b6e10d44b#88b456131de20750e785655d1e62cd0b6e10d44b"
+source = "git+https://github.com/tokio-rs/slab?rev=3340fdcf7204584b9ee509beabf3b174a333dfc1#3340fdcf7204584b9ee509beabf3b174a333dfc1"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
It has finally merged this 1.5 years old PR that adds `no_std` support :tada: 