### PR TITLE
Remove the `allocator_api` feature usage

### DIFF
--- a/kernel/standalone/src/lib.rs
+++ b/kernel/standalone/src/lib.rs
@@ -45,7 +45,6 @@
 //! as a dependency.
 
 #![no_std]
-#![feature(allocator_api)] // TODO: https://github.com/rust-lang/rust/issues/32838
 #![feature(alloc_error_handler)] // TODO: https://github.com/rust-lang/rust/issues/66741
 #![feature(asm_sym)] // TODO: https://github.com/rust-lang/rust/issues/72016
 #![feature(naked_functions)] // TODO: https://github.com/rust-lang/rust/issues/32408


### PR DESCRIPTION
cc https://github.com/tomaka/redshirt/issues/300